### PR TITLE
fix!: output correct line / column for utf16 source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive",
  "regex",
+ "ropey",
  "rustversion",
  "semver",
  "serde",
@@ -474,6 +475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ropey"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93411e420bcd1a75ddd1dc3caf18c23155eda2c090631a85af21ba19e97093b5"
+dependencies = [
+ "smallvec",
+ "str_indices",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,10 +578,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "str_indices"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 unicode-width = "0.2.0"
 cfg-if = "1.0.0"
+ropey = "1.6.1"
 
 owo-colors = { version = "4.1.0", optional = true }
 textwrap = { version = "0.16.1", optional = true }


### PR DESCRIPTION
**BREAKING CHANGE**:
we are no longer allowing `u8` vec or slice.

part of https://github.com/oxc-project/oxc/issues/9110

language_server has the implemantion: https://github.com/oxc-project/oxc/blob/4ca62abe43e4b19fa9c9605a4c866242031626fb/crates/oxc_language_server/src/linter/mod.rs

would do after the merge the same for the other formatters (using `ropey` crate)