### PR TITLE
chore: release v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.5.1] - 2025-09-28
+
+### Chore
+
+- *(deps)* Update github-actions ([#88](https://github.com/oxc-project/oxc-miette/pull/88))
+- *(deps)* Update dependency rust to v1.90.0 ([#87](https://github.com/oxc-project/oxc-miette/pull/87))
+- *(deps)* Update taiki-e/install-action action to v2.62.0 ([#90](https://github.com/oxc-project/oxc-miette/pull/90))
+- *(deps)* Lock file maintenance rust crates ([#91](https://github.com/oxc-project/oxc-miette/pull/91))
+- *(deps)* Update github-actions ([#92](https://github.com/oxc-project/oxc-miette/pull/92))
 
 ## [2.3.1](https://github.com/oxc-project/oxc-miette/compare/oxc-miette-v2.3.0...oxc-miette-v2.3.1) - 2025-06-27
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc-miette"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.5.0"
+version = "2.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "oxc-miette"
 description = "Fancy diagnostic reporting library and protocol for us mere mortals who aren't compiler hackers."
 documentation = "https://docs.rs/oxc-miette"
 readme = "README.md"
-version = "2.5.0"
+version = "2.5.1"
 authors.workspace = true
 categories.workspace = true
 repository.workspace = true
@@ -34,7 +34,7 @@ unit-bindings = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
 
 [dependencies]
-oxc-miette-derive = { path = "miette-derive", version = "=2.5.0", optional = true }
+oxc-miette-derive = { path = "miette-derive", version = "=2.5.1", optional = true }
 
 # Relaxed version so the user can decide which version to use.
 thiserror = "2"

--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxc-miette-derive"
 description = "Derive macros for miette. Like `thiserror` for Diagnostics."
-version = "2.5.0"
+version = "2.5.1"
 authors.workspace = true
 categories.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `oxc-miette-derive`: 2.5.0 -> 2.5.1
* `oxc-miette`: 2.5.0 -> 2.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `oxc-miette`

<blockquote>


## [2.5.1] - 2025-09-28

### Chore

- *(deps)* Update github-actions ([#88](https://github.com/oxc-project/oxc-miette/pull/88))
- *(deps)* Update dependency rust to v1.90.0 ([#87](https://github.com/oxc-project/oxc-miette/pull/87))
- *(deps)* Update taiki-e/install-action action to v2.62.0 ([#90](https://github.com/oxc-project/oxc-miette/pull/90))
- *(deps)* Lock file maintenance rust crates ([#91](https://github.com/oxc-project/oxc-miette/pull/91))
- *(deps)* Update github-actions ([#92](https://github.com/oxc-project/oxc-miette/pull/92))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).