### PR TITLE
chore: release v2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.5.2] - 2025-10-05
+
+### Chore
+
+- *(deps)* Update github-actions ([#93](https://github.com/oxc-project/oxc-miette/pull/93))
 ## [2.5.1] - 2025-09-28
 
 ### Chore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "oxc-miette"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "backtrace",
  "backtrace-ext",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette-derive"
-version = "2.5.1"
+version = "2.5.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "oxc-miette"
 description = "Fancy diagnostic reporting library and protocol for us mere mortals who aren't compiler hackers."
 documentation = "https://docs.rs/oxc-miette"
 readme = "README.md"
-version = "2.5.1"
+version = "2.5.2"
 authors.workspace = true
 categories.workspace = true
 repository.workspace = true
@@ -34,7 +34,7 @@ unit-bindings = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
 
 [dependencies]
-oxc-miette-derive = { path = "miette-derive", version = "=2.5.1", optional = true }
+oxc-miette-derive = { path = "miette-derive", version = "=2.5.2", optional = true }
 
 # Relaxed version so the user can decide which version to use.
 thiserror = "2"

--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oxc-miette-derive"
 description = "Derive macros for miette. Like `thiserror` for Diagnostics."
-version = "2.5.1"
+version = "2.5.2"
 authors.workspace = true
 categories.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `oxc-miette-derive`: 2.5.1 -> 2.5.2
* `oxc-miette`: 2.5.1 -> 2.5.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>


## `oxc-miette`

<blockquote>


## [2.5.2] - 2025-10-05

### Chore

- *(deps)* Update github-actions ([#93](https://github.com/oxc-project/oxc-miette/pull/93))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).