### PR TITLE
chore: use ubuntu-latest for security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,6 +19,6 @@ concurrency:
 jobs:
   security:
     name: Security Analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - uses: oxc-project/security-action@77e230508eccbb400b23746dab6c573a8ea7483e # v1.0.5


### PR DESCRIPTION
## Summary
- replace `ubuntu-slim` with `ubuntu-latest` in the security workflow

## Testing
- not run (GitHub Actions workflow config change only)
