### PR TITLE
perf!: store source spans as u32 to shrink LabeledSpan

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -1252,7 +1252,7 @@ impl GraphicalReportHandler {
         let context = std::str::from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
-        let mut offset = context_data.span().offset();
+        let mut offset = context_data.span().offset() as usize;
         let mut line_offset = offset;
         let mut line_str = String::with_capacity(context.len());
         let mut lines = Vec::with_capacity(1);
@@ -1429,10 +1429,10 @@ impl FancySpan {
     }
 
     fn offset(&self) -> usize {
-        self.span.offset()
+        self.span.offset() as usize
     }
 
     fn len(&self) -> usize {
-        self.span.len()
+        self.span.len() as usize
     }
 }

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -286,7 +286,7 @@ impl NarratableReportHandler {
         let context = std::str::from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
-        let mut offset = context_data.span().offset();
+        let mut offset = context_data.span().offset() as usize;
         let mut line_offset = offset;
         let mut iter = context.chars().peekable();
         let mut line_str = String::new();
@@ -386,14 +386,15 @@ fn safe_get_column(text: &str, offset: usize, start: bool) -> usize {
 
 impl Line {
     fn span_attach(&self, span: &SourceSpan) -> Option<SpanAttach> {
-        let span_end = span.offset() + span.len();
+        let span_offset = span.offset() as usize;
+        let span_end = span_offset + span.len() as usize;
         let line_end = self.offset + self.text.len();
 
-        let start_after = span.offset() >= self.offset;
+        let start_after = span_offset >= self.offset;
         let end_before = self.at_end_of_file || span_end <= line_end;
 
         if start_after && end_before {
-            let col_start = safe_get_column(&self.text, span.offset() - self.offset, true);
+            let col_start = safe_get_column(&self.text, span_offset - self.offset, true);
             let col_end = if span.is_empty() {
                 col_start
             } else {
@@ -403,8 +404,8 @@ impl Line {
             };
             return Some(SpanAttach::Contained { col_start, col_end });
         }
-        if start_after && span.offset() <= line_end {
-            let col_start = safe_get_column(&self.text, span.offset() - self.offset, true);
+        if start_after && span_offset <= line_end {
+            let col_start = safe_get_column(&self.text, span_offset - self.offset, true);
             return Some(SpanAttach::Starts { col_start });
         }
         if end_before && span_end >= self.offset {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -412,7 +412,7 @@
 //!     // You can add as many labels as you want.
 //!     // They'll be rendered sequentially.
 //!     #[label("This is bad")]
-//!     snip2: (usize, usize), // `(usize, usize)` is `Into<SourceSpan>`!
+//!     snip2: (u32, u32), // `(u32, u32)` is `Into<SourceSpan>`!
 //!
 //!     // Snippets can be optional, by using Option:
 //!     #[label("some text")]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -280,7 +280,7 @@ pub struct LabeledSpan {
 impl LabeledSpan {
     /// Makes a new labeled span.
     #[must_use]
-    pub const fn new(label: Option<String>, offset: ByteOffset, len: usize) -> Self {
+    pub const fn new(label: Option<String>, offset: ByteOffset, len: u32) -> Self {
         Self { label, span: SourceSpan::new(SourceOffset(offset), len), primary: false }
     }
 
@@ -302,7 +302,7 @@ impl LabeledSpan {
     }
 
     /// Change the offset of the span
-    pub fn set_span_offset(&mut self, offset: usize) {
+    pub fn set_span_offset(&mut self, offset: ByteOffset) {
         self.span.offset = SourceOffset(offset);
     }
 
@@ -367,12 +367,12 @@ impl LabeledSpan {
     }
 
     /// Returns the 0-based starting byte offset.
-    pub const fn offset(&self) -> usize {
+    pub const fn offset(&self) -> ByteOffset {
         self.span.offset()
     }
 
     /// Returns the number of bytes this `LabeledSpan` spans.
-    pub const fn len(&self) -> usize {
+    pub const fn len(&self) -> u32 {
         self.span.len()
     }
 
@@ -578,23 +578,23 @@ impl<'a> SpanContents<'a> for MietteSpanContents<'a> {
 pub struct SourceSpan {
     /// The start of the span.
     offset: SourceOffset,
-    /// The total length of the span
-    length: usize,
+    /// The total length of the span, in bytes.
+    length: u32,
 }
 
 impl SourceSpan {
     /// Create a new [`SourceSpan`].
-    pub const fn new(start: SourceOffset, length: usize) -> Self {
+    pub const fn new(start: SourceOffset, length: u32) -> Self {
         Self { offset: start, length }
     }
 
     /// The absolute offset, in bytes, from the beginning of a [`SourceCode`].
-    pub const fn offset(&self) -> usize {
+    pub const fn offset(&self) -> ByteOffset {
         self.offset.offset()
     }
 
     /// Total length of the [`SourceSpan`], in bytes.
-    pub const fn len(&self) -> usize {
+    pub const fn len(&self) -> u32 {
         self.length
     }
 
@@ -605,21 +605,21 @@ impl SourceSpan {
     }
 }
 
-impl From<(ByteOffset, usize)> for SourceSpan {
-    fn from((start, len): (ByteOffset, usize)) -> Self {
+impl From<(ByteOffset, u32)> for SourceSpan {
+    fn from((start, len): (ByteOffset, u32)) -> Self {
         Self { offset: start.into(), length: len }
     }
 }
 
-impl From<(SourceOffset, usize)> for SourceSpan {
-    fn from((start, len): (SourceOffset, usize)) -> Self {
+impl From<(SourceOffset, u32)> for SourceSpan {
+    fn from((start, len): (SourceOffset, u32)) -> Self {
         Self::new(start, len)
     }
 }
 
 impl From<std::ops::Range<ByteOffset>> for SourceSpan {
     fn from(range: std::ops::Range<ByteOffset>) -> Self {
-        Self { offset: range.start.into(), length: range.len() }
+        Self { offset: range.start.into(), length: range.end - range.start }
     }
 }
 
@@ -655,7 +655,7 @@ fn test_deserialize_source_span() {
 /**
 "Raw" type for the byte offset from the beginning of a [`SourceCode`].
 */
-pub type ByteOffset = usize;
+pub type ByteOffset = u32;
 
 /**
 Newtype that represents the [`ByteOffset`] from the beginning of a [`SourceCode`]
@@ -692,7 +692,7 @@ impl SourceOffset {
             offset += char.len_utf8();
         }
 
-        SourceOffset(offset)
+        SourceOffset(offset as u32)
     }
 
     /// Returns an offset for the _file_ location of wherever this function is
@@ -740,7 +740,7 @@ fn test_source_offset_from_location() {
     assert_eq!(SourceOffset::from_location(source, 4, 4).offset(), 10);
 
     // Out-of-range
-    assert_eq!(SourceOffset::from_location(source, 5, 1).offset(), source.len());
+    assert_eq!(SourceOffset::from_location(source, 5, 1).offset(), source.len() as u32);
 }
 
 #[cfg(feature = "serde")]

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -619,7 +619,9 @@ impl From<(SourceOffset, u32)> for SourceSpan {
 
 impl From<std::ops::Range<ByteOffset>> for SourceSpan {
     fn from(range: std::ops::Range<ByteOffset>) -> Self {
-        Self { offset: range.start.into(), length: range.end - range.start }
+        // `Range::len` returns `0` for empty/reversed ranges, matching the
+        // previous behavior and avoiding underflow.
+        Self { offset: range.start.into(), length: range.len() as u32 }
     }
 }
 

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -74,7 +74,7 @@ fn context_info<'a>(
         let starting_offset = before_lines_starts
             .front()
             .copied()
-            .unwrap_or_else(|| if context_lines_before == 0 { span_offset } else { 0 });
+            .unwrap_or(if context_lines_before == 0 { span_offset } else { 0 });
         Ok(MietteSpanContents::new(
             &input[starting_offset..offset],
             (starting_offset as u32, (offset - starting_offset) as u32).into(),

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -11,6 +11,8 @@ fn context_info<'a>(
     context_lines_before: usize,
     context_lines_after: usize,
 ) -> Result<MietteSpanContents<'a>, MietteError> {
+    let span_offset = span.offset() as usize;
+    let span_len = span.len() as usize;
     let mut offset = 0usize;
     let mut line_count = 0usize;
     let mut start_line = 0usize;
@@ -27,7 +29,7 @@ fn context_info<'a>(
             if char == b'\r' && iter.next_if_eq(&b'\n').is_some() {
                 offset += 1;
             }
-            if offset < span.offset() {
+            if offset < span_offset {
                 // We're before the start of the span.
                 start_column = 0;
                 before_lines_starts.push_back(current_line_start);
@@ -35,7 +37,7 @@ fn context_info<'a>(
                     start_line += 1;
                     before_lines_starts.pop_front();
                 }
-            } else if offset >= span.offset() + span.len().saturating_sub(1) {
+            } else if offset >= span_offset + span_len.saturating_sub(1) {
                 // We're after the end of the span, but haven't necessarily
                 // started collecting end lines yet (we might still be
                 // collecting context lines).
@@ -53,11 +55,11 @@ fn context_info<'a>(
                 }
             }
             current_line_start = offset + 1;
-        } else if offset < span.offset() {
+        } else if offset < span_offset {
             start_column += 1;
         }
 
-        if offset >= (span.offset() + span.len()).saturating_sub(1) {
+        if offset >= (span_offset + span_len).saturating_sub(1) {
             post_span = true;
             if end_lines >= context_lines_after {
                 offset += 1;
@@ -68,14 +70,14 @@ fn context_info<'a>(
         offset += 1;
     }
 
-    if offset >= (span.offset() + span.len()).saturating_sub(1) {
+    if offset >= (span_offset + span_len).saturating_sub(1) {
         let starting_offset = before_lines_starts
             .front()
             .copied()
-            .unwrap_or_else(|| if context_lines_before == 0 { span.offset() } else { 0 });
+            .unwrap_or_else(|| if context_lines_before == 0 { span_offset } else { 0 });
         Ok(MietteSpanContents::new(
             &input[starting_offset..offset],
-            (starting_offset, offset - starting_offset).into(),
+            (starting_offset as u32, (offset - starting_offset) as u32).into(),
             start_line,
             if context_lines_before == 0 { start_column } else { 0 },
             line_count,

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -255,13 +255,13 @@ fn test_snippet_named_struct() {
         var1: SourceSpan,
         #[label = "var 2"]
         // Anything that's Clone + Into<SourceSpan> can be used here.
-        var2: (usize, usize),
+        var2: (u32, u32),
         #[label]
-        var3: (usize, usize),
+        var3: (u32, u32),
         #[label("var 4")]
-        var4: Option<(usize, usize)>,
+        var4: Option<(u32, u32)>,
         #[label]
-        var5: Option<(usize, usize)>,
+        var5: Option<(u32, u32)>,
     }
 }
 
@@ -299,9 +299,9 @@ fn test_snippet_enum() {
             #[label]
             var2: SourceSpan,
             #[label("var 3")]
-            var3: Option<(usize, usize)>,
+            var3: Option<(u32, u32)>,
             #[label]
-            var4: Option<(usize, usize)>,
+            var4: Option<(u32, u32)>,
         },
         #[diagnostic(code(foo::b))]
         B(

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1125,7 +1125,7 @@ line4
 line5
 "#
     .to_string();
-    let len = src.len();
+    let len = src.len() as u32;
     let err = MyBad {
         src: NamedSource::new("bad_file.rs", src),
         highlight1: (0, len).into(),
@@ -1183,7 +1183,7 @@ line4
 line5
 "#
     .to_string();
-    let len = src.len();
+    let len = src.len() as u32;
     let err = MyBad {
         source: Inner(InnerInner),
         src: NamedSource::new("bad_file.rs", src),

--- a/tests/narrated.rs
+++ b/tests/narrated.rs
@@ -316,7 +316,7 @@ line4
 line5
 "#
     .to_string();
-    let len = src.len();
+    let len = src.len() as u32;
     let err = MyBad {
         src: NamedSource::new("bad_file.rs", src),
         highlight1: (0, len).into(),
@@ -379,7 +379,7 @@ line4
 line5
 "#
     .to_string();
-    let len = src.len();
+    let len = src.len() as u32;
     let err = MyBad {
         source: Inner(InnerInner),
         src: NamedSource::new("bad_file.rs", src),

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -158,7 +158,7 @@ fn test_boxed_custom_diagnostic() {
             report.labels().map(std::iter::Iterator::collect),
             Some(vec![LabeledSpan::new(Some(CustomDiagnostic::LABEL.to_owned()), 0, 7)]),
         );
-        let span = SourceSpan::from(0..CustomDiagnostic::SOURCE_CODE.len());
+        let span = SourceSpan::from(0..CustomDiagnostic::SOURCE_CODE.len() as u32);
         assert_eq!(
             report.source_code().map(|source_code| source_code
                 .read_span(&span, 0, 0)

--- a/tests/test_derive_attr.rs
+++ b/tests/test_derive_attr.rs
@@ -121,6 +121,6 @@ fn attr_not_required() {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad::Only { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
     let err_span = err.labels().unwrap().next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
 }

--- a/tests/test_derive_collection.rs
+++ b/tests/test_derive_collection.rs
@@ -30,13 +30,13 @@ fn attr_collection_in_enum() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -61,13 +61,13 @@ fn attr_collection_in_struct() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -92,13 +92,13 @@ fn attr_collection_as_deque() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -123,13 +123,13 @@ fn attr_collection_as_linked_list() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -143,7 +143,7 @@ fn attr_collection_of_tuple() {
         #[label("this bit here")]
         highlight: SourceSpan,
         #[label(collection, "and here")]
-        highlight2: Vec<(usize, usize)>,
+        highlight2: Vec<(u32, u32)>,
     }
 
     let src = "source\n  text\n    here".to_string();
@@ -154,13 +154,13 @@ fn attr_collection_of_tuple() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -174,7 +174,7 @@ fn attr_collection_of_range() {
         #[label("this bit here")]
         highlight: SourceSpan,
         #[label(collection, "and here")]
-        highlight2: Vec<Range<usize>>,
+        highlight2: Vec<Range<u32>>,
     }
 
     let src = "source\n  text\n    here".to_string();
@@ -185,13 +185,13 @@ fn attr_collection_of_range() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -219,13 +219,13 @@ fn attr_collection_of_labeled_span_in_struct() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("continuing here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("continuing here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("then there".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("then there".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -255,13 +255,13 @@ fn attr_collection_of_labeled_span_in_enum() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("continuing here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("continuing here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("then there".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("then there".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
 }
 
@@ -289,18 +289,18 @@ fn attr_collection_multi() {
     };
     let mut label_iter = err.labels().unwrap();
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("this bit here".into()), 9usize, 4usize);
+    let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 1usize, 2usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 1u32, 2u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and here".into()), 3usize, 4usize);
+    let expectation = LabeledSpan::new(Some("and here".into()), 3u32, 4u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and there".into()), 5usize, 6usize);
+    let expectation = LabeledSpan::new(Some("and there".into()), 5u32, 6u32);
     assert_eq!(err_span, expectation);
     let err_span = label_iter.next().unwrap();
-    let expectation = LabeledSpan::new(Some("and there".into()), 7usize, 8usize);
+    let expectation = LabeledSpan::new(Some("and there".into()), 7u32, 8u32);
     assert_eq!(err_span, expectation);
 }

--- a/tests/test_diagnostic_source_macro.rs
+++ b/tests/test_diagnostic_source_macro.rs
@@ -8,7 +8,7 @@ struct SourceError {
     #[help]
     help: String,
     #[label("here")]
-    label: (usize, usize),
+    label: (u32, u32),
 }
 
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
@@ -92,7 +92,7 @@ struct NestedError {
     #[source_code]
     code: String,
     #[label("here")]
-    label: (usize, usize),
+    label: (u32, u32),
     #[diagnostic_source]
     the_other_err: Box<dyn Diagnostic>,
 }

--- a/tests/test_emoji_underline.rs
+++ b/tests/test_emoji_underline.rs
@@ -19,7 +19,7 @@ fn test_emoji_sequence_underline() {
     let src = format!("before {} after", family_emoji);
     let err = TestError {
         src: NamedSource::new("test.txt", src.clone()),
-        span: (7, family_emoji.len()).into(),
+        span: (7, family_emoji.len() as u32).into(),
     };
 
     let mut output = String::new();
@@ -33,7 +33,7 @@ fn test_emoji_sequence_underline() {
     let src2 = format!("before {} after", flag_emoji);
     let err2 = TestError {
         src: NamedSource::new("test2.txt", src2.clone()),
-        span: (7, flag_emoji.len()).into(),
+        span: (7, flag_emoji.len() as u32).into(),
     };
 
     let mut output2 = String::new();
@@ -47,7 +47,7 @@ fn test_emoji_sequence_underline() {
     let src3 = format!("before {} after", skin_tone_emoji);
     let err3 = TestError {
         src: NamedSource::new("test3.txt", src3.clone()),
-        span: (7, skin_tone_emoji.len()).into(),
+        span: (7, skin_tone_emoji.len() as u32).into(),
     };
 
     let mut output3 = String::new();
@@ -61,7 +61,7 @@ fn test_emoji_sequence_underline() {
     let src4 = format!("before {} after", ascii_text);
     let err4 = TestError {
         src: NamedSource::new("test4.txt", src4.clone()),
-        span: (7, ascii_text.len()).into(),
+        span: (7, ascii_text.len() as u32).into(),
     };
 
     let mut output4 = String::new();

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -409,7 +409,7 @@ mod json_report_handler {
     line5
     "
         .to_string();
-        let len = src.len();
+        let len = src.len() as u32;
         let err = MyBad {
             src: NamedSource::new("bad_file.rs", src),
             highlight1: (0, len).into(),
@@ -487,7 +487,7 @@ mod json_report_handler {
     line5
     "
         .to_string();
-        let len = src.len();
+        let len = src.len() as u32;
         let err = MyBad {
             source: Inner(InnerInner),
             src: NamedSource::new("bad_file.rs", src),


### PR DESCRIPTION
## What

Change the storage and public API of `SourceSpan` / `SourceOffset` (and therefore `LabeledSpan`) from `usize` to `u32`.

This shrinks `LabeledSpan` from **48 → 40 bytes**.

## Why

Source files are bounded well below 4 GiB in practice, so a 32-bit byte offset is sufficient. The `usize` storage wasted 8 bytes per label on 64-bit targets. Downstream (oxc), spans are already `u32`, so this also removes a round-trip of `as usize` / `as u32` casts at every label construction and read site.

## Changes

- `SourceSpan.length` and `SourceOffset` now store `u32`
- `ByteOffset` is now `u32`
- Getters (`offset()`, `len()`) and constructors return/accept `u32`
- `(usize, usize)` / `Range<usize>` convenience conversions replaced with `u32` equivalents
- Handlers (`graphical`, `narratable`, `source_impls`) cast to `usize` only at the string-indexing boundary
- Tests updated to `u32`

## Notes

**Breaking change:** offsets/lengths are now `u32` instead of `usize`; offsets above `u32::MAX` are no longer representable.

All rendering and derive test suites pass. The pre-existing `color_format` env-flaky tests are unaffected by this change (they fail identically on `main`).