### PR TITLE
perf: store diagnostic labels inline to avoid allocations

### DIFF
--- a/miette-derive/src/forward.rs
+++ b/miette-derive/src/forward.rs
@@ -75,7 +75,7 @@ impl WhichFn {
                 fn related(&self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = &dyn miette::Diagnostic> + '_>>
             },
             Self::Labels => quote! {
-                fn labels(&self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = miette::LabeledSpan> + '_>>
+                fn labels(&self) -> miette::Labels
             },
             Self::SourceCode => quote! {
                 fn source_code(&self) -> std::option::Option<&dyn miette::SourceCode>
@@ -87,7 +87,10 @@ impl WhichFn {
     }
 
     pub fn catchall_arm(&self) -> TokenStream {
-        quote! { _ => std::option::Option::None }
+        match self {
+            Self::Labels => quote! { _ => miette::Labels::None },
+            _ => quote! { _ => std::option::Option::None },
+        }
     }
 }
 

--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -207,7 +207,7 @@ impl Labels {
                 use miette::macro_helpers::ToOption;
                 let Self #display_pat = self;
 
-                let labels_iter = vec![
+                let labels_iter = [
                     #(#labels),*
                 ]
                 .into_iter()
@@ -294,7 +294,7 @@ impl Labels {
                         _ => Some(quote! {
                             Self::#variant_name #display_pat => {
                                 use miette::macro_helpers::ToOption;
-                                let labels_iter = vec![
+                                let labels_iter = [
                                     #(#variant_labels),*
                                 ]
                                 .into_iter()

--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -203,7 +203,7 @@ impl Labels {
 
         Some(quote! {
             #[allow(unused_variables)]
-            fn labels(&self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = miette::LabeledSpan> + '_>> {
+            fn labels(&self) -> miette::Labels {
                 use miette::macro_helpers::ToOption;
                 let Self #display_pat = self;
 
@@ -213,7 +213,7 @@ impl Labels {
                 .into_iter()
                 #(#collections_chain)*;
 
-                std::option::Option::Some(Box::new(labels_iter.filter(Option::is_some).map(Option::unwrap)))
+                labels_iter.filter(Option::is_some).map(Option::unwrap).collect()
             }
         })
     }
@@ -299,7 +299,7 @@ impl Labels {
                                 ]
                                 .into_iter()
                                 #(#collections_chain)*;
-                                std::option::Option::Some(std::boxed::Box::new(labels_iter.filter(Option::is_some).map(Option::unwrap)))
+                                labels_iter.filter(Option::is_some).map(Option::unwrap).collect()
                             }
                         }),
                     }

--- a/src/eyreish/context.rs
+++ b/src/eyreish/context.rs
@@ -5,7 +5,7 @@ use super::{
     Report, WrapErr,
     error::{ContextError, ErrorImpl},
 };
-use crate::{Diagnostic, LabeledSpan};
+use crate::Diagnostic;
 
 mod ext {
     use super::*;
@@ -142,7 +142,7 @@ where
         self.error.url()
     }
 
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+    fn labels(&self) -> crate::Labels {
         self.error.labels()
     }
 
@@ -175,7 +175,7 @@ where
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).url() }
     }
 
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+    fn labels(&self) -> crate::Labels {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).labels() }
     }
 

--- a/src/eyreish/macros.rs
+++ b/src/eyreish/macros.rs
@@ -294,7 +294,20 @@ macro_rules! diagnostic {
     }};
     ($($key:ident = $value:expr_2021,)+ $fmt:literal $($arg:tt)*) => {{
         let mut diag = $crate::MietteDiagnostic::new(format!($fmt $($arg)*));
-        $(diag.$key = Some($value.into());)*
+        $($crate::__diagnostic_set_field!(diag, $key, $value);)*
         diag
     }};
+}
+
+/// Internal helper for [`diagnostic!`]: assigns a single field, special-casing
+/// `labels` since it is a [`Labels`](crate::Labels), not an `Option`.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __diagnostic_set_field {
+    ($diag:ident, labels, $value:expr_2021) => {
+        $diag.labels = ::core::iter::IntoIterator::into_iter($value).collect();
+    };
+    ($diag:ident, $key:ident, $value:expr_2021) => {
+        $diag.$key = Some($value.into());
+    };
 }

--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -2,7 +2,7 @@ use core::fmt::{self, Debug, Display};
 use std::error::Error as StdError;
 
 use crate as miette;
-use crate::{Diagnostic, LabeledSpan, Report, SourceCode};
+use crate::{Diagnostic, Report, SourceCode};
 
 #[repr(transparent)]
 pub(crate) struct MessageError<M>(pub(crate) M);
@@ -52,7 +52,7 @@ impl Diagnostic for BoxedError {
         self.0.url()
     }
 
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+    fn labels(&self) -> crate::Labels {
         self.0.labels()
     }
 
@@ -123,7 +123,7 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
         self.error.url()
     }
 
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+    fn labels(&self) -> crate::Labels {
         self.error.labels()
     }
 
@@ -161,7 +161,7 @@ impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
         self.error.url()
     }
 
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + 'a>> {
+    fn labels(&self) -> crate::Labels {
         self.error.labels()
     }
 
@@ -216,8 +216,8 @@ mod tests {
     }
 
     impl Diagnostic for Inner {
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-            Some(Box::new(std::iter::once(LabeledSpan::underline(self.at))))
+        fn labels(&self) -> crate::Labels {
+            crate::Labels::One([LabeledSpan::underline(self.at)])
         }
 
         fn source_code(&self) -> Option<&dyn SourceCode> {

--- a/src/handlers/debug.rs
+++ b/src/handlers/debug.rs
@@ -50,9 +50,9 @@ impl DebugReportHandler {
         if let Some(note) = diagnostic.note() {
             diag.field("note", &note.to_string());
         }
-        if let Some(labels) = diagnostic.labels() {
-            let labels: Vec<_> = labels.collect();
-            diag.field("labels", &format!("{labels:?}"));
+        let labels = diagnostic.labels();
+        if !labels.is_empty() {
+            diag.field("labels", &format!("{:?}", labels.as_slice()));
         }
         if let Some(cause) = diagnostic.diagnostic_source() {
             diag.field("caused by", &format!("{cause:?}"));

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -468,12 +468,10 @@ impl GraphicalReportHandler {
             Some(source) => source,
             None => return Ok(()),
         };
-        let labels = match diagnostic.labels() {
-            Some(labels) => labels,
-            None => return Ok(()),
-        };
-
-        let mut labels = labels.collect::<Vec<_>>();
+        let mut labels = diagnostic.labels();
+        if labels.is_empty() {
+            return Ok(());
+        }
         labels.sort_unstable_by_key(|l| l.inner().offset());
 
         let mut contexts = Vec::with_capacity(labels.len());

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -113,42 +113,37 @@ impl JSONReportHandler {
         if let Some(src) = src {
             self.render_snippets(f, diagnostic, src)?;
         }
-        match diagnostic.labels() {
-            Some(labels) => {
-                write!(f, r#""labels": ["#)?;
-                let mut add_comma = false;
-                for label in labels {
-                    if add_comma {
-                        write!(f, ",")?;
-                    } else {
-                        add_comma = true;
-                    }
-                    write!(f, "{{")?;
-                    if let Some(label_name) = label.label() {
-                        write!(f, r#""label": "{}","#, escape(label_name))?;
-                    }
-                    write!(f, r#""span": {{"#)?;
-                    write!(f, r#""offset": {},"#, label.offset())?;
-                    write!(f, r#""length": {},"#, label.len())?;
-
-                    if let Some(Ok(location)) = diagnostic
-                        .source_code()
-                        .or(parent_src)
-                        .map(|src| src.read_span(label.inner(), 0, 0))
-                    {
-                        write!(f, r#""line": {},"#, location.line() + 1)?;
-                        write!(f, r#""column": {}"#, location.column() + 1)?;
-                    } else {
-                        write!(f, r#""line": null,"column": null"#)?;
-                    }
-
-                    write!(f, "}}}}")?;
+        {
+            write!(f, r#""labels": ["#)?;
+            let mut add_comma = false;
+            for label in &diagnostic.labels() {
+                if add_comma {
+                    write!(f, ",")?;
+                } else {
+                    add_comma = true;
                 }
-                write!(f, "],")?;
+                write!(f, "{{")?;
+                if let Some(label_name) = label.label() {
+                    write!(f, r#""label": "{}","#, escape(label_name))?;
+                }
+                write!(f, r#""span": {{"#)?;
+                write!(f, r#""offset": {},"#, label.offset())?;
+                write!(f, r#""length": {},"#, label.len())?;
+
+                if let Some(Ok(location)) = diagnostic
+                    .source_code()
+                    .or(parent_src)
+                    .map(|src| src.read_span(label.inner(), 0, 0))
+                {
+                    write!(f, r#""line": {},"#, location.line() + 1)?;
+                    write!(f, r#""column": {}"#, location.column() + 1)?;
+                } else {
+                    write!(f, r#""line": null,"column": null"#)?;
+                }
+
+                write!(f, "}}}}")?;
             }
-            _ => {
-                write!(f, r#""labels": [],"#)?;
-            }
+            write!(f, "],")?;
         }
         match diagnostic.related() {
             Some(relates) => {
@@ -177,12 +172,10 @@ impl JSONReportHandler {
         diagnostic: &dyn Diagnostic,
         source: &dyn SourceCode,
     ) -> fmt::Result {
-        if let Some(mut labels) = diagnostic.labels() {
-            if let Some(label) = labels.next() {
-                if let Ok(span_content) = source.read_span(label.inner(), 0, 0) {
-                    let filename = span_content.name().unwrap_or_default();
-                    return write!(f, r#""filename": "{}","#, escape(filename));
-                }
+        if let Some(label) = diagnostic.labels().first() {
+            if let Ok(span_content) = source.read_span(label.inner(), 0, 0) {
+                let filename = span_content.name().unwrap_or_default();
+                return write!(f, r#""filename": "{}","#, escape(filename));
             }
         }
         write!(f, r#""filename": "","#)

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -159,8 +159,8 @@ impl NarratableReportHandler {
         source_code: Option<&dyn SourceCode>,
     ) -> fmt::Result {
         if let Some(source) = source_code {
-            if let Some(labels) = diagnostic.labels() {
-                let mut labels = labels.collect::<Vec<_>>();
+            {
+                let mut labels = diagnostic.labels();
                 labels.sort_unstable_by_key(|l| l.inner().offset());
                 if !labels.is_empty() {
                     let contents = labels

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -37,10 +37,7 @@ pub struct MietteDiagnostic {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub url: Option<String>,
     /// Labels to apply to this `Diagnostic`'s [`Diagnostic::source_code`]
-    #[cfg_attr(
-        feature = "serde",
-        serde(default, skip_serializing_if = "Labels::is_empty")
-    )]
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "Labels::is_empty"))]
     pub labels: Labels,
 }
 
@@ -188,11 +185,7 @@ impl FromIterator<LabeledSpan> for Labels {
 
 impl From<Vec<LabeledSpan>> for Labels {
     fn from(labels: Vec<LabeledSpan>) -> Self {
-        if labels.len() <= 2 {
-            labels.into_iter().collect()
-        } else {
-            Labels::Many(labels)
-        }
+        if labels.len() <= 2 { labels.into_iter().collect() } else { Labels::Many(labels) }
     }
 }
 

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -147,8 +147,19 @@ impl<'a> IntoIterator for &'a mut Labels {
 
 impl Extend<LabeledSpan> for Labels {
     fn extend<I: IntoIterator<Item = LabeledSpan>>(&mut self, iter: I) {
-        for label in iter {
-            self.push(label);
+        let mut iter = iter.into_iter();
+        // Fill the inline tiers first — allocation-free while staying at 1-2.
+        while !matches!(self, Labels::Many(_)) {
+            match iter.next() {
+                Some(label) => self.push(label),
+                None => return,
+            }
+        }
+        // Once on the heap, reserve once and bulk-extend instead of re-growing
+        // the `Vec` on every element.
+        if let Labels::Many(labels) = self {
+            labels.reserve(iter.size_hint().0);
+            labels.extend(iter);
         }
     }
 }
@@ -249,12 +260,8 @@ impl Diagnostic for MietteDiagnostic {
         self.url.as_ref().map(Box::new).map(|c| c as Box<dyn Display>)
     }
 
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        if self.labels.is_empty() {
-            None
-        } else {
-            Some(Box::new(self.labels.iter().cloned()))
-        }
+    fn labels(&self) -> Labels {
+        self.labels.clone()
     }
 }
 

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -37,8 +37,187 @@ pub struct MietteDiagnostic {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
     pub url: Option<String>,
     /// Labels to apply to this `Diagnostic`'s [`Diagnostic::source_code`]
-    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    pub labels: Option<Vec<LabeledSpan>>,
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Labels::is_empty")
+    )]
+    pub labels: Labels,
+}
+
+/// Container for a [`MietteDiagnostic`]'s labels.
+///
+/// Most diagnostics carry only one or two labels, so those cases are stored
+/// inline without a heap allocation. Diagnostics with three or more labels spill
+/// to a [`Vec`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum Labels {
+    /// No labels.
+    #[default]
+    None,
+    /// A single label, stored inline.
+    One([LabeledSpan; 1]),
+    /// Two labels, stored inline.
+    Two([LabeledSpan; 2]),
+    /// Three or more labels, stored on the heap.
+    Many(Vec<LabeledSpan>),
+}
+
+impl Labels {
+    /// Returns the labels as a contiguous slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[LabeledSpan] {
+        match self {
+            Labels::None => &[],
+            Labels::One(labels) => labels,
+            Labels::Two(labels) => labels,
+            Labels::Many(labels) => labels,
+        }
+    }
+
+    /// Returns the labels as a mutable contiguous slice.
+    #[must_use]
+    pub fn as_mut_slice(&mut self) -> &mut [LabeledSpan] {
+        match self {
+            Labels::None => &mut [],
+            Labels::One(labels) => labels,
+            Labels::Two(labels) => labels,
+            Labels::Many(labels) => labels,
+        }
+    }
+
+    /// Returns `true` if there are no labels.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Labels::None)
+    }
+
+    /// Returns the number of labels.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Appends a label, keeping the storage inline while possible.
+    pub fn push(&mut self, label: LabeledSpan) {
+        // Fast path: already on the heap, push in place without moving the `Vec`.
+        if let Labels::Many(labels) = self {
+            labels.push(label);
+            return;
+        }
+        *self = match std::mem::take(self) {
+            Labels::None => Labels::One([label]),
+            Labels::One([a]) => Labels::Two([a, label]),
+            Labels::Two([a, b]) => Labels::Many(vec![a, b, label]),
+            Labels::Many(_) => unreachable!("handled by the fast path above"),
+        };
+    }
+}
+
+impl std::ops::Deref for Labels {
+    type Target = [LabeledSpan];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl std::ops::DerefMut for Labels {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.as_mut_slice()
+    }
+}
+
+impl<'a> IntoIterator for &'a Labels {
+    type Item = &'a LabeledSpan;
+    type IntoIter = std::slice::Iter<'a, LabeledSpan>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_slice().iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut Labels {
+    type Item = &'a mut LabeledSpan;
+    type IntoIter = std::slice::IterMut<'a, LabeledSpan>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.as_mut_slice().iter_mut()
+    }
+}
+
+impl Extend<LabeledSpan> for Labels {
+    fn extend<I: IntoIterator<Item = LabeledSpan>>(&mut self, iter: I) {
+        for label in iter {
+            self.push(label);
+        }
+    }
+}
+
+impl FromIterator<LabeledSpan> for Labels {
+    fn from_iter<I: IntoIterator<Item = LabeledSpan>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+        // If the iterator already reports more than two elements, it will spill
+        // to the heap regardless, so collect straight into a `Vec`. For a
+        // `vec::IntoIter` source `collect` reuses the original allocation, so
+        // `with_labels(vec)` does not allocate at all.
+        if iter.size_hint().0 > 2 {
+            return Labels::Many(iter.collect());
+        }
+        // Otherwise pull up to three elements to pick the smallest variant
+        // that fits without allocating for the common one/two-label cases.
+        let Some(a) = iter.next() else { return Labels::None };
+        let Some(b) = iter.next() else { return Labels::One([a]) };
+        let Some(c) = iter.next() else { return Labels::Two([a, b]) };
+        let mut labels = Vec::with_capacity(3 + iter.size_hint().0);
+        labels.extend([a, b, c]);
+        labels.extend(iter);
+        Labels::Many(labels)
+    }
+}
+
+impl From<Vec<LabeledSpan>> for Labels {
+    fn from(labels: Vec<LabeledSpan>) -> Self {
+        if labels.len() <= 2 {
+            labels.into_iter().collect()
+        } else {
+            Labels::Many(labels)
+        }
+    }
+}
+
+impl From<LabeledSpan> for Labels {
+    fn from(label: LabeledSpan) -> Self {
+        Labels::One([label])
+    }
+}
+
+impl From<[LabeledSpan; 1]> for Labels {
+    fn from(labels: [LabeledSpan; 1]) -> Self {
+        Labels::One(labels)
+    }
+}
+
+impl From<[LabeledSpan; 2]> for Labels {
+    fn from(labels: [LabeledSpan; 2]) -> Self {
+        Labels::Two(labels)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Labels {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_slice().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for Labels {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // Accept both a sequence and `null` (the latter mirrors the previous
+        // `Option<Vec<LabeledSpan>>` representation).
+        let labels = Option::<Vec<LabeledSpan>>::deserialize(deserializer)?;
+        Ok(labels.map_or(Labels::None, Labels::from))
+    }
 }
 
 impl Display for MietteDiagnostic {
@@ -71,11 +250,11 @@ impl Diagnostic for MietteDiagnostic {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        self.labels
-            .as_ref()
-            .map(|ls| ls.iter().cloned())
-            .map(Box::new)
-            .map(|b| b as Box<dyn Iterator<Item = LabeledSpan>>)
+        if self.labels.is_empty() {
+            None
+        } else {
+            Some(Box::new(self.labels.iter().cloned()))
+        }
     }
 }
 
@@ -94,7 +273,7 @@ impl MietteDiagnostic {
     pub fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
-            labels: None,
+            labels: Labels::None,
             severity: None,
             code: None,
             help: None,
@@ -201,11 +380,11 @@ impl MietteDiagnostic {
     /// let label = LabeledSpan::at(0..3, "This should be Rust");
     /// let diag = MietteDiagnostic::new("Wrong best language").with_label(label.clone());
     /// assert_eq!(diag.message, "Wrong best language");
-    /// assert_eq!(diag.labels, Some(vec![label]));
+    /// assert_eq!(diag.labels.as_slice(), &[label]);
     /// ```
     #[must_use]
     pub fn with_label(mut self, label: impl Into<LabeledSpan>) -> Self {
-        self.labels = Some(vec![label.into()]);
+        self.labels = Labels::One([label.into()]);
         self
     }
 
@@ -225,11 +404,11 @@ impl MietteDiagnostic {
     /// ];
     /// let diag = MietteDiagnostic::new("Typos in 'hello world'").with_labels(labels.clone());
     /// assert_eq!(diag.message, "Typos in 'hello world'");
-    /// assert_eq!(diag.labels, Some(labels));
+    /// assert_eq!(diag.labels.as_slice(), labels.as_slice());
     /// ```
     #[must_use]
     pub fn with_labels(mut self, labels: impl IntoIterator<Item = LabeledSpan>) -> Self {
-        self.labels = Some(labels.into_iter().collect());
+        self.labels = labels.into_iter().collect();
         self
     }
 
@@ -247,13 +426,11 @@ impl MietteDiagnostic {
     ///     .and_label(label1.clone())
     ///     .and_label(label2.clone());
     /// assert_eq!(diag.message, "Typos in 'hello world'");
-    /// assert_eq!(diag.labels, Some(vec![label1, label2]));
+    /// assert_eq!(diag.labels.as_slice(), &[label1, label2]);
     /// ```
     #[must_use]
     pub fn and_label(mut self, label: impl Into<LabeledSpan>) -> Self {
-        let mut labels = self.labels.unwrap_or_default();
-        labels.push(label.into());
-        self.labels = Some(labels);
+        self.labels.push(label.into());
         self
     }
 
@@ -272,13 +449,11 @@ impl MietteDiagnostic {
     ///     .and_label(label1.clone())
     ///     .and_labels([label2.clone(), label3.clone()]);
     /// assert_eq!(diag.message, "Typos in 'hello world!'");
-    /// assert_eq!(diag.labels, Some(vec![label1, label2, label3]));
+    /// assert_eq!(diag.labels.as_slice(), &[label1, label2, label3]);
     /// ```
     #[must_use]
     pub fn and_labels(mut self, labels: impl IntoIterator<Item = LabeledSpan>) -> Self {
-        let mut all_labels = self.labels.unwrap_or_default();
-        all_labels.extend(labels);
-        self.labels = Some(all_labels);
+        self.labels.extend(labels);
         self
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -62,7 +62,7 @@ pub trait Diagnostic: std::error::Error {
 
     /// Labels to apply to this `Diagnostic`'s [`Diagnostic::source_code`]
     ///
-    /// Returns the owned [`Labels`] container. For the common one/two-label
+    /// Returns the owned [`Labels`](crate::Labels) container. For the common one/two-label
     /// case this is allocation-free (the labels are stored inline), and it
     /// avoids the boxed-iterator allocation the previous signature required.
     fn labels(&self) -> crate::Labels {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -272,7 +272,7 @@ pub trait SourceCode: Send + Sync {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LabeledSpan {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    label: Option<String>,
+    label: Option<Box<str>>,
     span: SourceSpan,
     primary: bool,
 }
@@ -280,25 +280,29 @@ pub struct LabeledSpan {
 impl LabeledSpan {
     /// Makes a new labeled span.
     #[must_use]
-    pub const fn new(label: Option<String>, offset: ByteOffset, len: u32) -> Self {
-        Self { label, span: SourceSpan::new(SourceOffset(offset), len), primary: false }
+    pub fn new(label: Option<String>, offset: ByteOffset, len: u32) -> Self {
+        Self {
+            label: label.map(String::into_boxed_str),
+            span: SourceSpan::new(SourceOffset(offset), len),
+            primary: false,
+        }
     }
 
     /// Makes a new labeled span using an existing span.
     #[must_use]
     pub fn new_with_span(label: Option<String>, span: impl Into<SourceSpan>) -> Self {
-        Self { label, span: span.into(), primary: false }
+        Self { label: label.map(String::into_boxed_str), span: span.into(), primary: false }
     }
 
     /// Makes a new labeled primary span using an existing span.
     #[must_use]
     pub fn new_primary_with_span(label: Option<String>, span: impl Into<SourceSpan>) -> Self {
-        Self { label, span: span.into(), primary: true }
+        Self { label: label.map(String::into_boxed_str), span: span.into(), primary: true }
     }
 
     /// Change the text of the label
     pub fn set_label(&mut self, label: Option<String>) {
-        self.label = label;
+        self.label = label.map(String::into_boxed_str);
     }
 
     /// Change the offset of the span

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -61,8 +61,12 @@ pub trait Diagnostic: std::error::Error {
     }
 
     /// Labels to apply to this `Diagnostic`'s [`Diagnostic::source_code`]
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        None
+    ///
+    /// Returns the owned [`Labels`] container. For the common one/two-label
+    /// case this is allocation-free (the labels are stored inline), and it
+    /// avoids the boxed-iterator allocation the previous signature required.
+    fn labels(&self) -> crate::Labels {
+        crate::Labels::None
     }
 
     /// Additional related `Diagnostic`s.

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -119,9 +119,8 @@ impl Diagnostic for CustomDiagnostic {
         Some(Box::new(Self::URL))
     }
 
-    fn labels<'a>(&'a self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + 'a>> {
-        let labels = miette::LabeledSpan::new(Some(Self::LABEL.to_owned()), 0, 7);
-        Some(Box::new(std::iter::once(labels)))
+    fn labels(&self) -> miette::Labels {
+        miette::Labels::One([miette::LabeledSpan::new(Some(Self::LABEL.to_owned()), 0, 7)])
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
@@ -155,8 +154,8 @@ fn test_boxed_custom_diagnostic() {
         );
         assert_eq!(report.url().map(|url| url.to_string()), Some(CustomDiagnostic::URL.to_owned()));
         assert_eq!(
-            report.labels().map(std::iter::Iterator::collect),
-            Some(vec![LabeledSpan::new(Some(CustomDiagnostic::LABEL.to_owned()), 0, 7)]),
+            report.labels().as_slice(),
+            &[LabeledSpan::new(Some(CustomDiagnostic::LABEL.to_owned()), 0, 7)],
         );
         let span = SourceSpan::from(0..CustomDiagnostic::SOURCE_CODE.len() as u32);
         assert_eq!(

--- a/tests/test_derive_attr.rs
+++ b/tests/test_derive_attr.rs
@@ -120,7 +120,7 @@ fn attr_not_required() {
 
     let src = "source\n  text\n    here".to_string();
     let err = MyBad::Only { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
-    let err_span = err.labels().unwrap().next().unwrap();
+    let err_span = err.labels().iter().next().cloned().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
 }

--- a/tests/test_derive_collection.rs
+++ b/tests/test_derive_collection.rs
@@ -28,7 +28,8 @@ fn attr_collection_in_enum() {
         highlight: (9, 4).into(),
         highlight2: vec![(1, 2).into(), (3, 4).into()],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -59,7 +60,8 @@ fn attr_collection_in_struct() {
         highlight: (9, 4).into(),
         highlight2: vec![(1, 2).into(), (3, 4).into()],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -90,7 +92,8 @@ fn attr_collection_as_deque() {
         highlight: (9, 4).into(),
         highlight2: VecDeque::from([(1, 2).into(), (3, 4).into()]),
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -121,7 +124,8 @@ fn attr_collection_as_linked_list() {
         highlight: (9, 4).into(),
         highlight2: LinkedList::from([(1, 2).into(), (3, 4).into()]),
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -152,7 +156,8 @@ fn attr_collection_of_tuple() {
         highlight: (9, 4).into(),
         highlight2: vec![(1, 2), (3, 4)],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -183,7 +188,8 @@ fn attr_collection_of_range() {
         highlight: (9, 4).into(),
         highlight2: vec![1..3, 3..7],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -217,7 +223,8 @@ fn attr_collection_of_labeled_span_in_struct() {
             LabeledSpan::new_with_span(None, (3, 4)),
         ],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -253,7 +260,8 @@ fn attr_collection_of_labeled_span_in_enum() {
             LabeledSpan::new_with_span(None, (3, 4)),
         ],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);
@@ -287,7 +295,8 @@ fn attr_collection_multi() {
         highlight2: vec![(1, 2).into(), (3, 4).into()],
         highlight3: vec![(5, 6).into(), (7, 8).into()],
     };
-    let mut label_iter = err.labels().unwrap();
+    let labels = err.labels();
+    let mut label_iter = labels.iter().cloned();
     let err_span = label_iter.next().unwrap();
     let expectation = LabeledSpan::new(Some("this bit here".into()), 9u32, 4u32);
     assert_eq!(err_span, expectation);


### PR DESCRIPTION
## Summary

`MietteDiagnostic` stored its labels in `Option<Vec<LabeledSpan>>`, so every diagnostic with a label heap-allocated a `Vec` — and the vast majority of diagnostics carry only **one or two** labels. On top of that, `Diagnostic::labels()` returned `Option<Box<dyn Iterator<…>>>`, allocating a boxed iterator on every call (and consumers then collected it into a `Vec`).

This PR makes labels allocation-free for the common case end to end.

## Storage: `Labels` enum

A `Labels` enum keeps one or two labels **inline** (fixed-size arrays) and only spills to a `Vec` at three or more. The `None` variant subsumes the old `Option`, so the field becomes `pub labels: Labels`.

- `with_label`/`and_label` are allocation-free for 1–2 labels.
- `with_labels`/`FromIterator` keep 1–2 inline; for 3+ from a `Vec` they reuse the source buffer via `collect`'s specialization.
- `Extend` fills the inline tiers, then reserves once and bulk-extends the spilled `Vec`.
- `LabeledSpan.label` shrinks `String` → `Box<str>` (40 B → 32 B); the enum reuses the `Box<str>` niche for its discriminant (zero tag overhead, `Labels` = 64 B).
- The derive macro emits a stack array instead of `vec![]`.

## Trait shape: `fn labels(&self) -> Labels`

`Diagnostic::labels` now returns the owned `Labels` container instead of a boxed iterator:

```rust
fn labels(&self) -> Labels { Labels::None }
```

- Storing impls return `self.labels.clone()` — no `Box`, and no heap allocation for 1–2 labels.
- Handlers own the result and sort it in place via `DerefMut`, dropping their `collect::<Vec<_>>()`.
- The derive macro and forwarding wrappers build/forward a `Labels`.

`Labels` implements `Deref`/`DerefMut` → `[LabeledSpan]`, `IntoIterator` (`&`/`&mut`), `Extend`, `FromIterator`, and `From<Vec>`/`From<LabeledSpan>`/`From<[_; 1|2]>`.

## Breaking changes

- `MietteDiagnostic.labels`: `Option<Vec<LabeledSpan>>` → `Labels`.
- `Diagnostic::labels`: `Option<Box<dyn Iterator<Item = LabeledSpan> + '_>>` → `Labels`.
- `LabeledSpan::new` is no longer `const` (it converts `String` → `Box<str>`).

serde round-trips the previous wire format (a sequence, or `null`). All lib tests and doctests pass.