### PR TITLE
perf: return Cow<str> from code/help/note/url instead of boxing

### DIFF
--- a/miette-derive/src/code.rs
+++ b/miette-derive/src/code.rs
@@ -58,13 +58,13 @@ impl Code {
                 let code = &code.as_ref()?.0;
                 Some(match fields {
                     syn::Fields::Named(_) => {
-                        quote! { Self::#ident { .. } => std::option::Option::Some(std::boxed::Box::new(#code)), }
+                        quote! { Self::#ident { .. } => std::option::Option::Some(std::borrow::Cow::Borrowed(#code)), }
                     }
                     syn::Fields::Unnamed(_) => {
-                        quote! { Self::#ident(..) => std::option::Option::Some(std::boxed::Box::new(#code)), }
+                        quote! { Self::#ident(..) => std::option::Option::Some(std::borrow::Cow::Borrowed(#code)), }
                     }
                     syn::Fields::Unit => {
-                        quote! { Self::#ident => std::option::Option::Some(std::boxed::Box::new(#code)), }
+                        quote! { Self::#ident => std::option::Option::Some(std::borrow::Cow::Borrowed(#code)), }
                     }
                 })
             },
@@ -74,8 +74,8 @@ impl Code {
     pub(crate) fn gen_struct(&self) -> Option<TokenStream> {
         let code = &self.0;
         Some(quote! {
-            fn code(&self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>> {
-                std::option::Option::Some(std::boxed::Box::new(#code))
+            fn code(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
+                std::option::Option::Some(std::borrow::Cow::Borrowed(#code))
             }
         })
     }

--- a/miette-derive/src/forward.rs
+++ b/miette-derive/src/forward.rs
@@ -60,13 +60,13 @@ impl WhichFn {
     pub fn signature(&self) -> TokenStream {
         match self {
             Self::Code => quote! {
-                fn code(& self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>>
+                fn code(&self) -> std::option::Option<std::borrow::Cow<'_, str>>
             },
             Self::Help => quote! {
-                fn help(& self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>>
+                fn help(&self) -> std::option::Option<std::borrow::Cow<'_, str>>
             },
             Self::Url => quote! {
-                fn url(& self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>>
+                fn url(&self) -> std::option::Option<std::borrow::Cow<'_, str>>
             },
             Self::Severity => quote! {
                 fn severity(&self) -> std::option::Option<miette::Severity>

--- a/miette-derive/src/help.rs
+++ b/miette-derive/src/help.rs
@@ -85,7 +85,7 @@ impl Help {
                     Help::Display(display) => {
                         let (fmt, args) = display.expand_shorthand_cloned(&display_members);
                         Some(quote! {
-                            Self::#ident #display_pat => std::option::Option::Some(std::boxed::Box::new(format!(#fmt #args))),
+                            Self::#ident #display_pat => std::option::Option::Some(std::borrow::Cow::Owned(format!(#fmt #args))),
                         })
                     }
                     Help::Field(member, ty) => {
@@ -99,7 +99,7 @@ impl Help {
                         Some(quote! {
                             Self::#ident #display_pat => {
                                 use miette::macro_helpers::ToOption;
-                                miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(&#help).as_ref().map(|#var| -> std::boxed::Box<dyn std::fmt::Display + '_> { std::boxed::Box::new(format!("{}", #var)) })
+                                miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(&#help).as_ref().map(|#var| -> std::borrow::Cow<'_, str> { std::borrow::Cow::Owned(format!("{}", #var)) })
                             },
                         })
                     }
@@ -114,21 +114,21 @@ impl Help {
             Help::Display(display) => {
                 let (fmt, args) = display.expand_shorthand_cloned(&display_members);
                 Some(quote! {
-                    fn help(&self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>> {
+                    fn help(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                         #[allow(unused_variables, deprecated)]
                         let Self #display_pat = self;
-                        std::option::Option::Some(std::boxed::Box::new(format!(#fmt #args)))
+                        std::option::Option::Some(std::borrow::Cow::Owned(format!(#fmt #args)))
                     }
                 })
             }
             Help::Field(member, ty) => {
                 let var = quote! { __miette_internal_var };
                 Some(quote! {
-                    fn help(&self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>> {
+                    fn help(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                         #[allow(unused_variables, deprecated)]
                         let Self #display_pat = self;
                         use miette::macro_helpers::ToOption;
-                        miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(&self.#member).as_ref().map(|#var| -> std::boxed::Box<dyn std::fmt::Display + '_> { std::boxed::Box::new(format!("{}", #var)) })
+                        miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(&self.#member).as_ref().map(|#var| -> std::borrow::Cow<'_, str> { std::borrow::Cow::Owned(format!("{}", #var)) })
                     }
                 })
             }

--- a/miette-derive/src/url.rs
+++ b/miette-derive/src/url.rs
@@ -92,7 +92,7 @@ impl Url {
                     }
                 };
                 Some(quote! {
-                    Self::#ident #pat => std::option::Option::Some(std::boxed::Box::new(format!(#fmt #args))),
+                    Self::#ident #pat => std::option::Option::Some(std::borrow::Cow::Owned(format!(#fmt #args))),
                 })
             },
         )
@@ -125,10 +125,10 @@ impl Url {
             }
         };
         Some(quote! {
-            fn url(&self) -> std::option::Option<std::boxed::Box<dyn std::fmt::Display + '_>> {
+            fn url(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                 #[allow(unused_variables, deprecated)]
                 let Self #pat = self;
-                std::option::Option::Some(std::boxed::Box::new(format!(#fmt #args)))
+                std::option::Option::Some(std::borrow::Cow::Owned(format!(#fmt #args)))
             }
         })
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::{fmt, io};
+use std::io;
 
 use thiserror::Error;
 
@@ -21,29 +21,31 @@ pub enum MietteError {
 }
 
 impl Diagnostic for MietteError {
-    fn code<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         match self {
-            MietteError::IoError(_) => Some(Box::new("miette::io_error")),
-            MietteError::OutOfBounds => Some(Box::new("miette::span_out_of_bounds")),
-        }
-    }
-
-    fn help<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
-        match self {
-            MietteError::IoError(_) => None,
+            MietteError::IoError(_) => Some(std::borrow::Cow::Borrowed("miette::io_error")),
             MietteError::OutOfBounds => {
-                Some(Box::new("Double-check your spans. Do you have an off-by-one error?"))
+                Some(std::borrow::Cow::Borrowed("miette::span_out_of_bounds"))
             }
         }
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn fmt::Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+        match self {
+            MietteError::IoError(_) => None,
+            MietteError::OutOfBounds => Some(std::borrow::Cow::Borrowed(
+                "Double-check your spans. Do you have an off-by-one error?",
+            )),
+        }
+    }
+
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         let crate_version = env!("CARGO_PKG_VERSION");
         let variant = match self {
             MietteError::IoError(_) => "#variant.IoError",
             MietteError::OutOfBounds => "#variant.OutOfBounds",
         };
-        Some(Box::new(format!(
+        Some(std::borrow::Cow::Owned(format!(
             "https://docs.rs/miette/{crate_version}/miette/enum.MietteError.html{variant}",
         )))
     }

--- a/src/eyreish/context.rs
+++ b/src/eyreish/context.rs
@@ -126,7 +126,7 @@ where
     D: Display,
     E: Diagnostic + 'static,
 {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.code()
     }
 
@@ -134,11 +134,11 @@ where
         self.error.severity()
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.help()
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.url()
     }
 
@@ -159,7 +159,7 @@ impl<D> Diagnostic for ContextError<D, Report>
 where
     D: Display,
 {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).code() }
     }
 
@@ -167,11 +167,11 @@ where
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).severity() }
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).help() }
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).url() }
     }
 

--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -32,7 +32,7 @@ impl<M> Diagnostic for MessageError<M> where M: Display + Debug + 'static {}
 pub(crate) struct BoxedError(pub(crate) Box<dyn Diagnostic + Send + Sync>);
 
 impl Diagnostic for BoxedError {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.0.code()
     }
 
@@ -40,15 +40,15 @@ impl Diagnostic for BoxedError {
         self.0.severity()
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.0.help()
     }
 
-    fn note<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.0.note()
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.0.url()
     }
 
@@ -103,7 +103,7 @@ pub(crate) struct WithSourceCode<E, C> {
 }
 
 impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.code()
     }
 
@@ -111,15 +111,15 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
         self.error.severity()
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.help()
     }
 
-    fn note<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.note()
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.url()
     }
 
@@ -141,7 +141,7 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
 }
 
 impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.code()
     }
 
@@ -149,15 +149,15 @@ impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
         self.error.severity()
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.help()
     }
 
-    fn note<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.note()
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         self.error.url()
     }
 

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -407,7 +407,7 @@ impl GraphicalReportHandler {
                 opts = opts.word_splitter(word_splitter);
             }
 
-            writeln!(f, "{}", self.wrap(&help.to_string(), opts))?;
+            writeln!(f, "{}", self.wrap(&help, opts))?;
         }
         if let Some(note) = diagnostic.note() {
             // Renders as:
@@ -425,7 +425,7 @@ impl GraphicalReportHandler {
                 opts = opts.word_splitter(word_splitter);
             }
 
-            writeln!(f, "{}", self.wrap(&note.to_string(), opts))?;
+            writeln!(f, "{}", self.wrap(&note, opts))?;
         }
         Ok(())
     }

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -73,7 +73,7 @@ impl JSONReportHandler {
     ) -> fmt::Result {
         write!(f, r#"{{"message": "{}","#, escape(&diagnostic.to_string()))?;
         if let Some(code) = diagnostic.code() {
-            write!(f, r#""code": "{}","#, escape(&code.to_string()))?;
+            write!(f, r#""code": "{}","#, escape(&code))?;
         }
         let severity = match diagnostic.severity() {
             Some(Severity::Error) | None => "error",
@@ -104,10 +104,10 @@ impl JSONReportHandler {
             write!(f, r#""url": "{}","#, &url.to_string())?;
         }
         if let Some(help) = diagnostic.help() {
-            write!(f, r#""help": "{}","#, escape(&help.to_string()))?;
+            write!(f, r#""help": "{}","#, escape(&help))?;
         }
         if let Some(note) = diagnostic.note() {
-            write!(f, r#""note": "{}","#, escape(&note.to_string()))?;
+            write!(f, r#""note": "{}","#, escape(&note))?;
         }
         let src = diagnostic.source_code().or(parent_src);
         if let Some(src) = src {

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -233,24 +233,24 @@ impl Display for MietteDiagnostic {
 impl Error for MietteDiagnostic {}
 
 impl Diagnostic for MietteDiagnostic {
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.code.as_ref().map(Box::new).map(|c| c as Box<dyn Display>)
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+        self.code.as_deref().map(std::borrow::Cow::Borrowed)
     }
 
     fn severity(&self) -> Option<Severity> {
         self.severity
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.help.as_ref().map(Box::new).map(|c| c as Box<dyn Display>)
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+        self.help.as_deref().map(std::borrow::Cow::Borrowed)
     }
 
-    fn note<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.note.as_ref().map(Box::new).map(|c| c as Box<dyn Display>)
+    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
+        self.note.as_deref().map(std::borrow::Cow::Borrowed)
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
-        self.url.as_ref().map(Box::new).map(|c| c as Box<dyn Display>)
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+        self.url.as_deref().map(std::borrow::Cow::Borrowed)
     }
 
     fn labels(&self) -> Labels {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -23,7 +23,7 @@ pub trait Diagnostic: std::error::Error {
     /// in the toplevel crate's documentation for easy searching. Rust path
     /// format (`foo::bar::baz`) is recommended, but more classic codes like
     /// `E0123` or enums will work just fine.
-    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
         None
     }
 
@@ -38,20 +38,20 @@ pub trait Diagnostic: std::error::Error {
 
     /// Additional help text related to this `Diagnostic`. Do you have any
     /// advice for the poor soul who's just run into this issue?
-    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
         None
     }
 
     /// Supplementary context for this `Diagnostic`, separate from help text.
     /// Notes mirror rustc-style `= note:` lines and offer additional
     /// information when guidance (help) is insufficient.
-    fn note<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
         None
     }
 
     /// URL to visit for a more detailed explanation/help about this
     /// `Diagnostic`.
-    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
         None
     }
 

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -103,20 +103,20 @@ impl StdError for CustomDiagnostic {
 }
 
 impl Diagnostic for CustomDiagnostic {
-    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        Some(Box::new(Self::CODE))
+    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+        Some(std::borrow::Cow::Borrowed(Self::CODE))
     }
 
     fn severity(&self) -> Option<miette::Severity> {
         Some(miette::Severity::Advice)
     }
 
-    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        Some(Box::new(Self::HELP))
+    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+        Some(std::borrow::Cow::Borrowed(Self::HELP))
     }
 
-    fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        Some(Box::new(Self::URL))
+    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+        Some(std::borrow::Cow::Borrowed(Self::URL))
     }
 
     fn labels(&self) -> miette::Labels {

--- a/tests/test_note.rs
+++ b/tests/test_note.rs
@@ -223,7 +223,7 @@ mod trait_implementation_tests {
     #[test]
     fn diagnostic_trait_note_method_exists() {
         let diag = MietteDiagnostic::new("test");
-        let _note: Option<Box<dyn std::fmt::Display>> = diag.note();
+        let _note: Option<std::borrow::Cow<'_, str>> = diag.note();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Diagnostic::{code, help, note, url}` returned `Option<Box<dyn Display + '_>>`, heap-allocating a box on **every call** — up to four boxes per rendered diagnostic.

This changes them to return `Option<Cow<'_, str>>`:

- Diagnostics that store these as strings return `Cow::Borrowed` — **zero allocation** (the old `Box::new(&self.field)` always allocated a box).
- Dynamically-built values (derive `help`/`url` via `format!`, `MietteError::url`) return `Cow::Owned` — the same single allocation they already performed, just without the extra box.
- Handlers use the `Cow` directly (it derefs to `str`), dropping now-redundant `to_string()` calls.

`Cow<str>` is the right shape here because some impls store the value (want to borrow) while the derive macro builds it dynamically (must own) — same tension the `labels()` change resolved, solved here with `Cow`.

## Breaking changes

- `Diagnostic::code` / `help` / `note` / `url`: `Option<Box<dyn Display + '_>>` → `Option<Cow<'_, str>>`.

Updated the trait, `MietteDiagnostic`, `MietteError`, the eyreish wrappers/context forwarders, the derive macro (code/help/url codegen + forward signatures), and all handlers. All lib tests, doctests, derive tests, fmt, clippy, and docs pass.