### PR TITLE
perf: return concrete MietteSpanContents from SourceCode::read_span

### DIFF
--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -206,7 +206,7 @@ impl<C> StdError for WithSourceCode<Report, C> {
 mod tests {
     use thiserror::Error;
 
-    use crate::{Diagnostic, LabeledSpan, Report, SourceCode, SourceSpan};
+    use crate::{Diagnostic, LabeledSpan, Report, SourceCode, SourceSpan, SpanContents};
 
     #[derive(Error, Debug)]
     #[error("inner")]

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -8,8 +8,8 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::{
-    Diagnostic, GraphicalTheme, LabeledSpan, ReportHandler, Severity, SourceCode, SourceSpan,
-    SpanContents, ThemeCharacters,
+    Diagnostic, GraphicalTheme, LabeledSpan, MietteSpanContents, ReportHandler, Severity,
+    SourceCode, SourceSpan, SpanContents, ThemeCharacters,
 };
 
 #[derive(Debug, Clone)]
@@ -1243,7 +1243,7 @@ impl GraphicalReportHandler {
         &'a self,
         source: &'a dyn SourceCode,
         context_span: &'a SourceSpan,
-    ) -> Result<(Box<dyn SpanContents<'a> + 'a>, Vec<Line>), fmt::Error> {
+    ) -> Result<(MietteSpanContents<'a>, Vec<Line>), fmt::Error> {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -1,7 +1,8 @@
 use std::fmt::{self, Write};
 
 use crate::{
-    ReportHandler, Severity, SourceCode, diagnostic_chain::DiagnosticChain, protocol::Diagnostic,
+    ReportHandler, Severity, SourceCode, SpanContents, diagnostic_chain::DiagnosticChain,
+    protocol::Diagnostic,
 };
 
 /**

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{
-    LabeledSpan, MietteError, ReportHandler, SourceCode, SourceSpan, SpanContents,
+    LabeledSpan, MietteError, MietteSpanContents, ReportHandler, SourceCode, SourceSpan,
+    SpanContents,
     diagnostic_chain::DiagnosticChain,
     protocol::{Diagnostic, Severity},
 };
@@ -168,7 +169,7 @@ impl NarratableReportHandler {
                         .map(|label| {
                             source.read_span(label.inner(), self.context_lines, self.context_lines)
                         })
-                        .collect::<Result<Vec<Box<dyn SpanContents<'_>>>, MietteError>>()
+                        .collect::<Result<Vec<MietteSpanContents<'_>>, MietteError>>()
                         .map_err(|_| fmt::Error)?;
                     let mut contexts = Vec::new();
                     for (right, right_conts) in labels.iter().cloned().zip(contents.iter()) {
@@ -279,7 +280,7 @@ impl NarratableReportHandler {
         &'a self,
         source: &'a dyn SourceCode,
         context_span: &'a SourceSpan,
-    ) -> Result<(Box<dyn SpanContents<'a> + 'a>, Vec<Line>), fmt::Error> {
+    ) -> Result<(MietteSpanContents<'a>, Vec<Line>), fmt::Error> {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -55,7 +55,7 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
         span: &crate::SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         let inner_contents =
             self.inner().read_span(span, context_lines_before, context_lines_after)?;
         let mut contents = MietteSpanContents::new_named(
@@ -69,7 +69,7 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
         if let Some(language) = &self.language {
             contents = contents.with_language(language);
         }
-        Ok(Box::new(contents))
+        Ok(contents)
     }
 
     fn name(&self) -> Option<&str> {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -263,7 +263,7 @@ pub trait SourceCode: Send + Sync {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError>;
+    ) -> Result<MietteSpanContents<'a>, MietteError>;
 
     /// Returns the name of this source code, if any.
     fn name(&self) -> Option<&str> {

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -3,7 +3,7 @@ Default trait implementations for [`SourceCode`].
 */
 use std::{borrow::Cow, collections::VecDeque, fmt::Debug, sync::Arc};
 
-use crate::{MietteError, MietteSpanContents, SourceCode, SourceSpan, SpanContents};
+use crate::{MietteError, MietteSpanContents, SourceCode, SourceSpan};
 
 fn context_info<'a>(
     input: &'a [u8],
@@ -93,9 +93,9 @@ impl SourceCode for [u8] {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         let contents = context_info(self, span, context_lines_before, context_lines_after)?;
-        Ok(Box::new(contents))
+        Ok(contents)
     }
 }
 
@@ -105,7 +105,7 @@ impl SourceCode for &[u8] {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -116,7 +116,7 @@ impl SourceCode for Vec<u8> {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -127,7 +127,7 @@ impl SourceCode for str {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         <[u8] as SourceCode>::read_span(
             self.as_bytes(),
             span,
@@ -144,7 +144,7 @@ impl SourceCode for &str {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -155,7 +155,7 @@ impl SourceCode for String {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
 }
@@ -166,7 +166,7 @@ impl<T: ?Sized + SourceCode> SourceCode for Arc<T> {
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         self.as_ref().read_span(span, context_lines_before, context_lines_after)
     }
 
@@ -189,7 +189,7 @@ where
         span: &SourceSpan,
         context_lines_before: usize,
         context_lines_after: usize,
-    ) -> Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
         self.as_ref().read_span(span, context_lines_before, context_lines_after)
     }
 
@@ -201,6 +201,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SpanContents;
 
     #[test]
     fn basic() -> Result<(), MietteError> {

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -1,6 +1,6 @@
 use std::{error::Error as StdError, io};
 
-use miette::{Diagnostic, LabeledSpan, Report, SourceSpan, miette};
+use miette::{Diagnostic, LabeledSpan, Report, SourceSpan, SpanContents, miette};
 use thiserror::Error;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
## Summary

`SourceCode::read_span` returned `Result<Box<dyn SpanContents<'a> + 'a>, MietteError>`, heap-allocating a trait-object box on **every call** — and it's called once per label while rendering, so it's on the hot path.

`MietteSpanContents` is the **only** `SpanContents` implementor, and every `read_span` impl already builds one and boxes it. This returns it directly:

```rust
fn read_span(...) -> Result<MietteSpanContents<'a>, MietteError>;
```

That removes one box per span read (per label, per render). Handlers store/return the concrete `MietteSpanContents` instead of `Box<dyn SpanContents>`.

## Breaking change

- `SourceCode::read_span` return type: `Box<dyn SpanContents<'a> + 'a>` → `MietteSpanContents<'a>`. Custom `SourceCode` impls must return `MietteSpanContents` (drop the `Box::new`). Consumers calling `.data()/.line()/.column()/.name()` need `SpanContents` in scope (it still works via the trait).

All lib/doc/derive tests, fmt, and clippy pass.