### PR TITLE
perf: return inline Related from Diagnostic::related

### DIFF
--- a/miette-derive/src/forward.rs
+++ b/miette-derive/src/forward.rs
@@ -72,7 +72,7 @@ impl WhichFn {
                 fn severity(&self) -> std::option::Option<miette::Severity>
             },
             Self::Related => quote! {
-                fn related(&self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = &dyn miette::Diagnostic> + '_>>
+                fn related(&self) -> miette::Related<'_>
             },
             Self::Labels => quote! {
                 fn labels(&self) -> miette::Labels
@@ -89,6 +89,7 @@ impl WhichFn {
     pub fn catchall_arm(&self) -> TokenStream {
         match self {
             Self::Labels => quote! { _ => miette::Labels::None },
+            Self::Related => quote! { _ => miette::Related::None },
             _ => quote! { _ => std::option::Option::None },
         }
     }

--- a/miette-derive/src/related.rs
+++ b/miette-derive/src/related.rs
@@ -52,9 +52,7 @@ impl Related {
                     };
                     quote! {
                         Self::#ident #display_pat => {
-                            std::option::Option::Some(std::boxed::Box::new(
-                                #rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x })
-                            ))
+                            #rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x }).collect()
                         }
                     }
                 })
@@ -65,11 +63,9 @@ impl Related {
     pub(crate) fn gen_struct(&self) -> Option<TokenStream> {
         let rel = &self.0;
         Some(quote! {
-            fn related<'a>(&'a self) -> std::option::Option<std::boxed::Box<dyn std::iter::Iterator<Item = &'a dyn miette::Diagnostic> + 'a>> {
+            fn related(&self) -> miette::Related<'_> {
                 use ::core::borrow::Borrow;
-                std::option::Option::Some(std::boxed::Box::new(
-                        self.#rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x.borrow() })
-                ))
+                self.#rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x.borrow() }).collect()
             }
         })
     }

--- a/src/eyreish/context.rs
+++ b/src/eyreish/context.rs
@@ -150,7 +150,7 @@ where
         self.error.source_code()
     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+    fn related(&self) -> crate::Related<'_> {
         self.error.related()
     }
 }
@@ -183,7 +183,7 @@ where
         self.error.source_code()
     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+    fn related(&self) -> crate::Related<'_> {
         self.error.related()
     }
 }

--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -60,7 +60,7 @@ impl Diagnostic for BoxedError {
         self.0.source_code()
     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+    fn related(&self) -> crate::Related<'_> {
         self.0.related()
     }
 
@@ -131,7 +131,7 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
         self.error.source_code().or(Some(&self.source_code))
     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+    fn related(&self) -> crate::Related<'_> {
         self.error.related()
     }
 
@@ -169,7 +169,7 @@ impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
         self.error.source_code().or(Some(&self.source_code))
     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+    fn related(&self) -> crate::Related<'_> {
         self.error.related()
     }
 
@@ -233,8 +233,8 @@ mod tests {
     }
 
     impl Diagnostic for Outer {
-        fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
-            Some(Box::new(self.errors.iter().map(|e| e as _)))
+        fn related(&self) -> crate::Related<'_> {
+            self.errors.iter().map(|e| e as &dyn Diagnostic).collect()
         }
     }
 

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -436,12 +436,13 @@ impl GraphicalReportHandler {
         diagnostic: &dyn Diagnostic,
         parent_src: Option<&dyn SourceCode>,
     ) -> fmt::Result {
-        if let Some(related) = diagnostic.related() {
+        let related = diagnostic.related();
+        if !related.is_empty() {
             let mut inner_renderer = self.clone();
             // Re-enable the printing of nested cause chains for related errors
             inner_renderer.with_cause_chain = true;
             writeln!(f)?;
-            for rel in related {
+            for rel in related.iter().copied() {
                 match rel.severity() {
                     Some(Severity::Error) | None => write!(f, "Error: ")?,
                     Some(Severity::Warning) => write!(f, "Warning: ")?,

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -146,23 +146,21 @@ impl JSONReportHandler {
             }
             write!(f, "],")?;
         }
-        match diagnostic.related() {
-            Some(relates) => {
-                write!(f, r#""related": ["#)?;
-                let mut add_comma = false;
-                for related in relates {
-                    if add_comma {
-                        write!(f, ",")?;
-                    } else {
-                        add_comma = true;
-                    }
-                    self._render_report(f, related, src)?;
+        let relates = diagnostic.related();
+        if relates.is_empty() {
+            write!(f, r#""related": []"#)?;
+        } else {
+            write!(f, r#""related": ["#)?;
+            let mut add_comma = false;
+            for related in relates.iter().copied() {
+                if add_comma {
+                    write!(f, ",")?;
+                } else {
+                    add_comma = true;
                 }
-                write!(f, "]")?;
+                self._render_report(f, related, src)?;
             }
-            _ => {
-                write!(f, r#""related": []"#)?;
-            }
+            write!(f, "]")?;
         }
         write!(f, "}}")
     }

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -133,9 +133,10 @@ impl NarratableReportHandler {
         diagnostic: &dyn Diagnostic,
         parent_src: Option<&dyn SourceCode>,
     ) -> fmt::Result {
-        if let Some(related) = diagnostic.related() {
+        let related = diagnostic.related();
+        if !related.is_empty() {
             writeln!(f)?;
-            for rel in related {
+            for rel in related.iter().copied() {
                 match rel.severity() {
                     Some(Severity::Error) | None => write!(f, "Error: ")?,
                     Some(Severity::Warning) => write!(f, "Warning: ")?,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -70,13 +70,113 @@ pub trait Diagnostic: std::error::Error {
     }
 
     /// Additional related `Diagnostic`s.
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
-        None
+    ///
+    /// Returns the owned [`Related`] container. For the common one/two-related
+    /// case this is allocation-free, and it avoids the boxed-iterator
+    /// allocation the previous signature required.
+    fn related(&self) -> Related<'_> {
+        Related::None
     }
 
     /// The cause of the error.
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
         None
+    }
+}
+
+/// Container for a [`Diagnostic`]'s related diagnostics.
+///
+/// Most diagnostics carry only one or two related entries, so those cases are
+/// stored inline without a heap allocation. Three or more spill to a [`Vec`].
+#[derive(Default)]
+pub enum Related<'a> {
+    /// No related diagnostics.
+    #[default]
+    None,
+    /// A single related diagnostic, stored inline.
+    One([&'a dyn Diagnostic; 1]),
+    /// Two related diagnostics, stored inline.
+    Two([&'a dyn Diagnostic; 2]),
+    /// Three or more related diagnostics, stored on the heap.
+    Many(Vec<&'a dyn Diagnostic>),
+}
+
+impl<'a> Related<'a> {
+    /// Returns the related diagnostics as a contiguous slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[&'a dyn Diagnostic] {
+        match self {
+            Related::None => &[],
+            Related::One(related) => related,
+            Related::Two(related) => related,
+            Related::Many(related) => related,
+        }
+    }
+
+    /// Returns `true` if there are no related diagnostics.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Related::None)
+    }
+
+    /// Returns the number of related diagnostics.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+
+    /// Appends a related diagnostic, keeping the storage inline while possible.
+    pub fn push(&mut self, related: &'a dyn Diagnostic) {
+        if let Related::Many(items) = self {
+            items.push(related);
+            return;
+        }
+        *self = match std::mem::take(self) {
+            Related::None => Related::One([related]),
+            Related::One([a]) => Related::Two([a, related]),
+            Related::Two([a, b]) => Related::Many(vec![a, b, related]),
+            Related::Many(_) => unreachable!("handled by the fast path above"),
+        };
+    }
+}
+
+impl<'a> std::ops::Deref for Related<'a> {
+    type Target = [&'a dyn Diagnostic];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<'a> Extend<&'a dyn Diagnostic> for Related<'a> {
+    fn extend<I: IntoIterator<Item = &'a dyn Diagnostic>>(&mut self, iter: I) {
+        let mut iter = iter.into_iter();
+        while !matches!(self, Related::Many(_)) {
+            match iter.next() {
+                Some(related) => self.push(related),
+                None => return,
+            }
+        }
+        if let Related::Many(items) = self {
+            items.reserve(iter.size_hint().0);
+            items.extend(iter);
+        }
+    }
+}
+
+impl<'a> FromIterator<&'a dyn Diagnostic> for Related<'a> {
+    fn from_iter<I: IntoIterator<Item = &'a dyn Diagnostic>>(iter: I) -> Self {
+        let mut iter = iter.into_iter();
+        if iter.size_hint().0 > 2 {
+            return Related::Many(iter.collect());
+        }
+        let Some(a) = iter.next() else { return Related::None };
+        let Some(b) = iter.next() else { return Related::One([a]) };
+        let Some(c) = iter.next() else { return Related::Two([a, b]) };
+        let mut items = Vec::with_capacity(3 + iter.size_hint().0);
+        items.extend([a, b, c]);
+        items.extend(iter);
+        Related::Many(items)
     }
 }
 

--- a/tests/narrated.rs
+++ b/tests/narrated.rs
@@ -578,7 +578,6 @@ snippet line 1: source
 snippet line 2:   text
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-
 "#
     .trim_start()
     .to_string();

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -127,8 +127,8 @@ impl Diagnostic for CustomDiagnostic {
         Some(&Self::SOURCE_CODE)
     }
 
-    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
-        Some(Box::new(self.related.iter().map(|d| &**d as &'a dyn Diagnostic)))
+    fn related(&self) -> miette::Related<'_> {
+        self.related.iter().map(|d| &**d as &dyn Diagnostic).collect()
     }
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {


### PR DESCRIPTION
## Summary

`Diagnostic::related` returned `Option<Box<dyn Iterator<Item = &dyn Diagnostic> + '_>>`, heap-allocating a boxed iterator on **every call**.

This returns an owned `Related<'_>` container — an enum that stores one or two related references **inline** (fixed-size arrays of `&dyn Diagnostic`) and only spills to a `Vec` at three or more. The `None` variant subsumes the old `Option`.

- Diagnostics with 1–2 related entries allocate nothing.
- `Related` impls `Deref` → `[&dyn Diagnostic]`, `FromIterator`, `Extend`, `push` — mirroring `Labels`.
- The derive macro and the eyreish wrappers/context forwarders build/forward a `Related`; handlers iterate `related.iter().copied()`.

This is the last of the `Box`/`Vec`-returning trait-method APIs (after `labels`, `code/help/note/url`, and `read_span`).

## Breaking change

- `Diagnostic::related`: `Option<Box<dyn Iterator<Item = &dyn Diagnostic> + '_>>` → `Related<'_>`.

All lib/doc/derive/boxed tests, fmt, and clippy pass.