### PR TITLE
perf: avoid allocating a styled label just to test its presence

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -652,7 +652,7 @@ impl GraphicalReportHandler {
                 )?;
             }
             for hl in multi_line {
-                if hl.label().is_some() && line.span_ends(hl) && !line.span_starts(hl) {
+                if hl.has_label() && line.span_ends(hl) && !line.span_starts(hl) {
                     self.render_multi_line_end(f, &labels, max_gutter, linum_width, line, hl)?;
                 }
             }
@@ -775,7 +775,7 @@ impl GraphicalReportHandler {
                 arrow = true;
                 break;
             } else if line.span_ends(hl) {
-                if hl.label().is_some() {
+                if hl.has_label() {
                     gutter.push_str(&chars.lcross.style(hl.style).to_string());
                 } else {
                     gutter.push_str(&chars.lbot.style(hl.style).to_string());
@@ -1107,7 +1107,7 @@ impl GraphicalReportHandler {
                         chars.underline.to_string().repeat(num_left),
                         if hl.len() == 0 {
                             chars.uarrow
-                        } else if hl.label().is_some() {
+                        } else if hl.has_label() {
                             chars.underbar
                         } else {
                             chars.underline
@@ -1419,8 +1419,8 @@ impl FancySpan {
         self.style
     }
 
-    fn label(&self) -> Option<String> {
-        self.label.as_ref().map(|l| l.join("\n").style(self.style()).to_string())
+    fn has_label(&self) -> bool {
+        self.label.is_some()
     }
 
     fn label_parts(&self) -> Option<Vec<String>> {


### PR DESCRIPTION
## Summary

`FancySpan::label()` built `label.join("\n").style(..).to_string()` — **three allocations** (join + style + to_string) — but three hot call sites in the graphical renderer used it only as `hl.label().is_some()`:

- `render_context` (multi-line label check)
- `render_line_gutter`
- `render_single_line_highlights` (underline char selection)

These run **per highlight, per rendered line**, allocating and immediately discarding a styled `String` just to test whether a label exists.

This adds a cheap `has_label()` (`self.label.is_some()`) for the presence checks and removes the now-unused `label()` method. Actual label rendering already goes through `label_parts()`, which is unchanged.

Internal change only — no public API affected. All lib/doc/fancy tests, fmt, and clippy pass.