### PR TITLE
perf: move the line buffer into Line instead of cloning it

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -1287,9 +1287,8 @@ impl GraphicalReportHandler {
                     line_number: line,
                     offset: line_offset,
                     length: offset - line_offset,
-                    text: line_str.clone(),
+                    text: std::mem::take(&mut line_str),
                 });
-                line_str.clear();
                 line_offset = offset;
             }
         }

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -327,10 +327,9 @@ impl NarratableReportHandler {
                 lines.push(Line {
                     line_number: line,
                     offset: line_offset,
-                    text: line_str.clone(),
+                    text: std::mem::take(&mut line_str),
                     at_end_of_file,
                 });
-                line_str.clear();
                 line_offset = offset;
             }
         }


### PR DESCRIPTION
## Summary

`get_lines` (in both the graphical and narratable handlers) accumulated each source line into a reusable `line_str` buffer, then pushed `line_str.clone()` into the `Line` struct and `clear()`ed the buffer — a full copy allocation **per source line**.

Use `std::mem::take(&mut line_str)` to move the buffer into the `Line` instead, leaving a fresh empty buffer for the next line. No clone, identical output.

Internal change only. All lib/doc/fancy snapshot tests, fmt, and clippy pass.