### PR TITLE
perf: borrow name/language in MietteSpanContents instead of cloning

### DIFF
--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -59,7 +59,7 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
         let inner_contents =
             self.inner().read_span(span, context_lines_before, context_lines_after)?;
         let mut contents = MietteSpanContents::new_named(
-            self.name.clone(),
+            std::borrow::Cow::Borrowed(self.name.as_str()),
             inner_contents.data(),
             *inner_contents.span(),
             inner_contents.line(),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -605,9 +605,9 @@ pub struct MietteSpanContents<'a> {
     // Number of line in this snippet.
     line_count: usize,
     // Optional filename
-    name: Option<String>,
+    name: Option<std::borrow::Cow<'a, str>>,
     // Optional language
-    language: Option<String>,
+    language: Option<std::borrow::Cow<'a, str>>,
 }
 
 impl<'a> MietteSpanContents<'a> {
@@ -624,7 +624,7 @@ impl<'a> MietteSpanContents<'a> {
 
     /// Make a new [`MietteSpanContents`] object, with a name for its 'file'.
     pub const fn new_named(
-        name: String,
+        name: std::borrow::Cow<'a, str>,
         data: &'a [u8],
         span: SourceSpan,
         line: usize,
@@ -644,7 +644,7 @@ impl<'a> MietteSpanContents<'a> {
 
     /// Sets the `language` for syntax highlighting.
     #[must_use]
-    pub fn with_language(mut self, language: impl Into<String>) -> Self {
+    pub fn with_language(mut self, language: impl Into<std::borrow::Cow<'a, str>>) -> Self {
         self.language = Some(language.into());
         self
     }


### PR DESCRIPTION
## Summary

`MietteSpanContents` stored `name` and `language` as owned `String`s, but only ever exposed them as `&str` (via `name()`/`language()`). As a result `NamedSource::read_span` cloned the source name into every `MietteSpanContents` it built — **once per label, per render**.

Store them as `Cow<'a, str>` and have `new_named` take a `Cow` / `with_language` take `impl Into<Cow>`, so callers can borrow. `read_span` now passes `Cow::Borrowed(self.name.as_str())` — no clone.

## Breaking change

- `MietteSpanContents::new_named` takes `Cow<'a, str>` (was `String`).
- `MietteSpanContents::with_language` takes `impl Into<Cow<'a, str>>` (was `impl Into<String>`).

All lib/doc/fancy snapshot tests, fmt, and clippy pass.