### PR TITLE
perf: style FancySpan label parts once at construction

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -1137,7 +1137,7 @@ impl GraphicalReportHandler {
                     )?;
                 } else {
                     let mut first = true;
-                    for label_line in &label {
+                    for label_line in label {
                         self.write_label_text(
                             f,
                             line,
@@ -1402,25 +1402,21 @@ impl PartialEq for FancySpan {
     }
 }
 
-fn split_label(v: &str) -> Vec<String> {
-    v.split('\n').map(|i| i.to_string()).collect()
+fn split_label(v: &str, style: Style) -> Vec<String> {
+    v.split('\n').map(|i| i.style(style).to_string()).collect()
 }
 
 impl FancySpan {
     fn new(label: Option<&str>, span: SourceSpan, style: Style) -> Self {
-        FancySpan { label: label.map(split_label), span, style }
-    }
-
-    fn style(&self) -> Style {
-        self.style
+        FancySpan { label: label.map(|l| split_label(l, style)), span, style }
     }
 
     fn has_label(&self) -> bool {
         self.label.is_some()
     }
 
-    fn label_parts(&self) -> Option<Vec<String>> {
-        self.label.as_ref().map(|l| l.iter().map(|i| i.style(self.style()).to_string()).collect())
+    fn label_parts(&self) -> Option<&[String]> {
+        self.label.as_deref()
     }
 
     fn offset(&self) -> usize {


### PR DESCRIPTION
## Summary

`FancySpan` stored its label as raw (unstyled) lines (`Vec<String>`), and `label_parts()` re-allocated a **styled** `Vec<String>` on every call — once per label, per render, on top of the raw `Vec<String>` already built at construction. That's two `Vec<String>` allocations per label per render.

Apply the style when the parts are first built (`split_label` now takes the `Style`) and store them already-styled, so `label_parts()` just borrows them as `&[String]` — no per-render allocation. Removes one `Vec<String>` + its per-line `String`s per label per render.

Output is **byte-identical** (the same styled strings, just computed once at construction instead of per render) — all `fancy` snapshot tests pass. The now-redundant `FancySpan::style()` accessor is removed.

Internal change only — no public API affected. lib/doc/fancy tests, fmt, clippy all pass.