### PR TITLE
perf: revert LabeledSpan.label to String to avoid a realloc per label

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -376,7 +376,7 @@ pub trait SourceCode: Send + Sync {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LabeledSpan {
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-    label: Option<Box<str>>,
+    label: Option<String>,
     span: SourceSpan,
     primary: bool,
 }
@@ -384,29 +384,25 @@ pub struct LabeledSpan {
 impl LabeledSpan {
     /// Makes a new labeled span.
     #[must_use]
-    pub fn new(label: Option<String>, offset: ByteOffset, len: u32) -> Self {
-        Self {
-            label: label.map(String::into_boxed_str),
-            span: SourceSpan::new(SourceOffset(offset), len),
-            primary: false,
-        }
+    pub const fn new(label: Option<String>, offset: ByteOffset, len: u32) -> Self {
+        Self { label, span: SourceSpan::new(SourceOffset(offset), len), primary: false }
     }
 
     /// Makes a new labeled span using an existing span.
     #[must_use]
     pub fn new_with_span(label: Option<String>, span: impl Into<SourceSpan>) -> Self {
-        Self { label: label.map(String::into_boxed_str), span: span.into(), primary: false }
+        Self { label, span: span.into(), primary: false }
     }
 
     /// Makes a new labeled primary span using an existing span.
     #[must_use]
     pub fn new_primary_with_span(label: Option<String>, span: impl Into<SourceSpan>) -> Self {
-        Self { label: label.map(String::into_boxed_str), span: span.into(), primary: true }
+        Self { label, span: span.into(), primary: true }
     }
 
     /// Change the text of the label
     pub fn set_label(&mut self, label: Option<String>) {
-        self.label = label.map(String::into_boxed_str);
+        self.label = label;
     }
 
     /// Change the offset of the span


### PR DESCRIPTION
## Summary

PR #182 changed `LabeledSpan.label` from `String` to `Box<str>` to shrink the struct by 8 bytes. But every constructor then calls `String::into_boxed_str()`, which `shrink_to_fit()`s — **reallocating whenever the label `String` has spare capacity** (anything built with `format!`, which most diagnostic labels are).

In oxc's allocation benchmark (`just allocs`) this shows up as ~1 extra sys realloc **per labeled diagnostic**:

```
checker.ts   sys reallocs: 10 -> 1518   (allocs 5303 -> 3543)
```

The alloc count dropped (inline `Labels` removed the per-diagnostic `Vec`) but each label now pays a shrink-realloc — a bad trade on the hot diagnostic-construction path. The 8-byte struct shrink is not worth a reallocation per label.

## Fix

Revert `LabeledSpan.label` to `String`, storing the caller's `String` as-is (no `into_boxed_str`, no shrink). `LabeledSpan::new` becomes `const` again. The inline `Labels` enum storage from #182 is kept — only the `Box<str>` shrink is undone.

`label()` still returns `Option<&str>`, so no downstream change. All lib/doc/fancy tests, fmt, clippy pass.