### PR TITLE
perf: borrow source lines in the renderer instead of allocating a String each

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -673,7 +673,7 @@ impl GraphicalReportHandler {
         labels: &[FancySpan],
         max_gutter: usize,
         linum_width: usize,
-        line: &Line,
+        line: &Line<'_>,
         label: &FancySpan,
     ) -> fmt::Result {
         // no line number!
@@ -750,7 +750,7 @@ impl GraphicalReportHandler {
         &self,
         f: &mut impl fmt::Write,
         max_gutter: usize,
-        line: &Line,
+        line: &Line<'_>,
         highlights: &[FancySpan],
     ) -> fmt::Result {
         if max_gutter == 0 {
@@ -806,7 +806,7 @@ impl GraphicalReportHandler {
         &self,
         f: &mut impl fmt::Write,
         max_gutter: usize,
-        line: &Line,
+        line: &Line<'_>,
         highlights: &[FancySpan],
         render_mode: LabelRenderMode,
     ) -> fmt::Result {
@@ -1021,7 +1021,7 @@ impl GraphicalReportHandler {
     /// If the offset occurs in the middle of a character, the returned column
     /// corresponds to that character's first column in `start` is true, or its
     /// last column if `start` is false.
-    fn visual_offset(&self, line: &Line, offset: usize, start: bool) -> usize {
+    fn visual_offset(&self, line: &Line<'_>, offset: usize, start: bool) -> usize {
         let line_range = line.offset..=(line.offset + line.length);
         assert!(line_range.contains(&offset));
 
@@ -1068,7 +1068,7 @@ impl GraphicalReportHandler {
     fn render_single_line_highlights(
         &self,
         f: &mut impl fmt::Write,
-        line: &Line,
+        line: &Line<'_>,
         linum_width: usize,
         max_gutter: usize,
         single_liners: &[&FancySpan],
@@ -1168,7 +1168,7 @@ impl GraphicalReportHandler {
     fn write_label_text(
         &self,
         f: &mut impl fmt::Write,
-        line: &Line,
+        line: &Line<'_>,
         linum_width: usize,
         max_gutter: usize,
         all_highlights: &[FancySpan],
@@ -1240,16 +1240,22 @@ impl GraphicalReportHandler {
         &'a self,
         source: &'a dyn SourceCode,
         context_span: &'a SourceSpan,
-    ) -> Result<(MietteSpanContents<'a>, Vec<Line>), fmt::Error> {
+    ) -> Result<(MietteSpanContents<'a>, Vec<Line<'a>>), fmt::Error> {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;
         let context = std::str::from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
+        // Byte offset into the original source.
         let mut offset = context_data.span().offset() as usize;
+        // Byte offset of `context[0]` into the original source, used to map a
+        // source offset to an index into `context`.
+        let base = offset;
         let mut line_offset = offset;
-        let mut line_str = String::with_capacity(context.len());
+        // Number of bytes of visible text accumulated for the current line
+        // (i.e. excluding the line terminator).
+        let mut line_len = 0usize;
         let mut lines = Vec::with_capacity(1);
         let mut iter = context.chars().peekable();
         while let Some(char) = iter.next() {
@@ -1262,7 +1268,7 @@ impl GraphicalReportHandler {
                         line += 1;
                         column = 0;
                     } else {
-                        line_str.push(char);
+                        line_len += char.len_utf8();
                         column += 1;
                     }
                     at_end_of_file = iter.peek().is_none();
@@ -1273,7 +1279,7 @@ impl GraphicalReportHandler {
                     column = 0;
                 }
                 _ => {
-                    line_str.push(char);
+                    line_len += char.len_utf8();
                     column += 1;
                 }
             }
@@ -1283,13 +1289,16 @@ impl GraphicalReportHandler {
             }
 
             if column == 0 || iter.peek().is_none() {
+                // The visible text is a contiguous slice of `context`, starting
+                // at the line's offset and excluding the line terminator.
+                let text_start = line_offset - base;
                 lines.push(Line {
                     line_number: line,
                     offset: line_offset,
                     length: offset - line_offset,
-                    text: line_str.clone(),
+                    text: &context[text_start..text_start + line_len],
                 });
-                line_str.clear();
+                line_len = 0;
                 line_offset = offset;
             }
         }
@@ -1322,14 +1331,14 @@ enum LabelRenderMode {
 }
 
 #[derive(Debug)]
-struct Line {
+struct Line<'a> {
     line_number: usize,
     offset: usize,
     length: usize,
-    text: String,
+    text: &'a str,
 }
 
-impl Line {
+impl Line<'_> {
     fn span_line_only(&self, span: &FancySpan) -> bool {
         span.offset() >= self.offset && span.offset() + span.len() <= self.offset + self.length
     }

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -281,7 +281,7 @@ impl NarratableReportHandler {
         &'a self,
         source: &'a dyn SourceCode,
         context_span: &'a SourceSpan,
-    ) -> Result<(MietteSpanContents<'a>, Vec<Line>), fmt::Error> {
+    ) -> Result<(MietteSpanContents<'a>, Vec<Line<'a>>), fmt::Error> {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;
@@ -289,9 +289,12 @@ impl NarratableReportHandler {
         let mut line = context_data.line();
         let mut column = context_data.column();
         let mut offset = context_data.span().offset() as usize;
+        // Byte offset of `context[0]` into the original source.
+        let base = offset;
         let mut line_offset = offset;
         let mut iter = context.chars().peekable();
-        let mut line_str = String::new();
+        // Bytes of visible text accumulated for the current line (no terminator).
+        let mut line_len = 0usize;
         let mut lines = Vec::new();
         while let Some(char) = iter.next() {
             offset += char.len_utf8();
@@ -303,7 +306,7 @@ impl NarratableReportHandler {
                         line += 1;
                         column = 0;
                     } else {
-                        line_str.push(char);
+                        line_len += char.len_utf8();
                         column += 1;
                     }
                     at_end_of_file = iter.peek().is_none();
@@ -314,7 +317,7 @@ impl NarratableReportHandler {
                     column = 0;
                 }
                 _ => {
-                    line_str.push(char);
+                    line_len += char.len_utf8();
                     column += 1;
                 }
             }
@@ -324,13 +327,14 @@ impl NarratableReportHandler {
             }
 
             if column == 0 || iter.peek().is_none() {
+                let text_start = line_offset - base;
                 lines.push(Line {
                     line_number: line,
                     offset: line_offset,
-                    text: line_str.clone(),
+                    text: &context[text_start..text_start + line_len],
                     at_end_of_file,
                 });
-                line_str.clear();
+                line_len = 0;
                 line_offset = offset;
             }
         }
@@ -352,10 +356,10 @@ impl ReportHandler for NarratableReportHandler {
 Support types
 */
 
-struct Line {
+struct Line<'a> {
     line_number: usize,
     offset: usize,
-    text: String,
+    text: &'a str,
     at_end_of_file: bool,
 }
 
@@ -386,7 +390,7 @@ fn safe_get_column(text: &str, offset: usize, start: bool) -> usize {
     column
 }
 
-impl Line {
+impl Line<'_> {
     fn span_attach(&self, span: &SourceSpan) -> Option<SpanAttach> {
         let span_offset = span.offset() as usize;
         let span_end = span_offset + span.len() as usize;
@@ -396,22 +400,22 @@ impl Line {
         let end_before = self.at_end_of_file || span_end <= line_end;
 
         if start_after && end_before {
-            let col_start = safe_get_column(&self.text, span_offset - self.offset, true);
+            let col_start = safe_get_column(self.text, span_offset - self.offset, true);
             let col_end = if span.is_empty() {
                 col_start
             } else {
                 // span_end refers to the next character after token
                 // while col_end refers to the exact character, so -1
-                safe_get_column(&self.text, span_end - self.offset, false)
+                safe_get_column(self.text, span_end - self.offset, false)
             };
             return Some(SpanAttach::Contained { col_start, col_end });
         }
         if start_after && span_offset <= line_end {
-            let col_start = safe_get_column(&self.text, span_offset - self.offset, true);
+            let col_start = safe_get_column(self.text, span_offset - self.offset, true);
             return Some(SpanAttach::Starts { col_start });
         }
         if end_before && span_end >= self.offset {
-            let col_end = safe_get_column(&self.text, span_end - self.offset, false);
+            let col_end = safe_get_column(self.text, span_end - self.offset, false);
             return Some(SpanAttach::Ends { col_end });
         }
         None


### PR DESCRIPTION
## Summary

The graphical and narratable handlers' `get_lines` allocated **one owned `String` per rendered source line** (`Line.text`) — the largest per-render heap allocation, a copy of the source text itself.

The line text is always a contiguous slice of the already-borrowed snippet buffer (the line minus its terminator), so this makes `Line` borrow it instead:

- `Line<'a>` with `text: &'a str` (was `String`), sliced from `context` by byte offsets.
- `get_lines` tracks the line's byte length instead of pushing chars into a `String`.
- The borrowed `MietteSpanContents` is returned alongside `Vec<Line<'a>>`, so the slices stay valid for the render.

**Eliminates all per-line source-text allocations during rendering.** For a snippet of N lines that's N fewer `String` allocations per diagnostic render.

Output is **byte-identical** — verified by the graphical and narratable snapshot tests (`--features fancy`). Internal change only, no public API. fmt + clippy clean.