### PR TITLE
refactor: import Cow at the top instead of fully-qualifying inline

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{borrow::Cow, io};
 
 use thiserror::Error;
 
@@ -21,31 +21,29 @@ pub enum MietteError {
 }
 
 impl Diagnostic for MietteError {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         match self {
-            MietteError::IoError(_) => Some(std::borrow::Cow::Borrowed("miette::io_error")),
+            MietteError::IoError(_) => Some(Cow::Borrowed("miette::io_error")),
+            MietteError::OutOfBounds => Some(Cow::Borrowed("miette::span_out_of_bounds")),
+        }
+    }
+
+    fn help(&self) -> Option<Cow<'_, str>> {
+        match self {
+            MietteError::IoError(_) => None,
             MietteError::OutOfBounds => {
-                Some(std::borrow::Cow::Borrowed("miette::span_out_of_bounds"))
+                Some(Cow::Borrowed("Double-check your spans. Do you have an off-by-one error?"))
             }
         }
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
-        match self {
-            MietteError::IoError(_) => None,
-            MietteError::OutOfBounds => Some(std::borrow::Cow::Borrowed(
-                "Double-check your spans. Do you have an off-by-one error?",
-            )),
-        }
-    }
-
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         let crate_version = env!("CARGO_PKG_VERSION");
         let variant = match self {
             MietteError::IoError(_) => "#variant.IoError",
             MietteError::OutOfBounds => "#variant.OutOfBounds",
         };
-        Some(std::borrow::Cow::Owned(format!(
+        Some(Cow::Owned(format!(
             "https://docs.rs/miette/{crate_version}/miette/enum.MietteError.html{variant}",
         )))
     }

--- a/src/eyreish/context.rs
+++ b/src/eyreish/context.rs
@@ -1,5 +1,5 @@
 use core::fmt::{self, Debug, Display, Write};
-use std::error::Error as StdError;
+use std::{borrow::Cow, error::Error as StdError};
 
 use super::{
     Report, WrapErr,
@@ -126,7 +126,7 @@ where
     D: Display,
     E: Diagnostic + 'static,
 {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         self.error.code()
     }
 
@@ -134,11 +134,11 @@ where
         self.error.severity()
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn help(&self) -> Option<Cow<'_, str>> {
         self.error.help()
     }
 
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         self.error.url()
     }
 
@@ -159,7 +159,7 @@ impl<D> Diagnostic for ContextError<D, Report>
 where
     D: Display,
 {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).code() }
     }
 
@@ -167,11 +167,11 @@ where
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).severity() }
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn help(&self) -> Option<Cow<'_, str>> {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).help() }
     }
 
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         unsafe { ErrorImpl::diagnostic(self.error.inner.by_ref()).url() }
     }
 

--- a/src/eyreish/wrapper.rs
+++ b/src/eyreish/wrapper.rs
@@ -1,5 +1,5 @@
 use core::fmt::{self, Debug, Display};
-use std::error::Error as StdError;
+use std::{borrow::Cow, error::Error as StdError};
 
 use crate as miette;
 use crate::{Diagnostic, Report, SourceCode};
@@ -32,7 +32,7 @@ impl<M> Diagnostic for MessageError<M> where M: Display + Debug + 'static {}
 pub(crate) struct BoxedError(pub(crate) Box<dyn Diagnostic + Send + Sync>);
 
 impl Diagnostic for BoxedError {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         self.0.code()
     }
 
@@ -40,15 +40,15 @@ impl Diagnostic for BoxedError {
         self.0.severity()
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn help(&self) -> Option<Cow<'_, str>> {
         self.0.help()
     }
 
-    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn note(&self) -> Option<Cow<'_, str>> {
         self.0.note()
     }
 
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         self.0.url()
     }
 
@@ -103,7 +103,7 @@ pub(crate) struct WithSourceCode<E, C> {
 }
 
 impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         self.error.code()
     }
 
@@ -111,15 +111,15 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
         self.error.severity()
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn help(&self) -> Option<Cow<'_, str>> {
         self.error.help()
     }
 
-    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn note(&self) -> Option<Cow<'_, str>> {
         self.error.note()
     }
 
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         self.error.url()
     }
 
@@ -141,7 +141,7 @@ impl<E: Diagnostic, C: SourceCode> Diagnostic for WithSourceCode<E, C> {
 }
 
 impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         self.error.code()
     }
 
@@ -149,15 +149,15 @@ impl<C: SourceCode> Diagnostic for WithSourceCode<Report, C> {
         self.error.severity()
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn help(&self) -> Option<Cow<'_, str>> {
         self.error.help()
     }
 
-    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn note(&self) -> Option<Cow<'_, str>> {
         self.error.note()
     }
 
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         self.error.url()
     }
 

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     error::Error,
     fmt::{Debug, Display},
 };
@@ -233,24 +234,24 @@ impl Display for MietteDiagnostic {
 impl Error for MietteDiagnostic {}
 
 impl Diagnostic for MietteDiagnostic {
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
-        self.code.as_deref().map(std::borrow::Cow::Borrowed)
+    fn code(&self) -> Option<Cow<'_, str>> {
+        self.code.as_deref().map(Cow::Borrowed)
     }
 
     fn severity(&self) -> Option<Severity> {
         self.severity
     }
 
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
-        self.help.as_deref().map(std::borrow::Cow::Borrowed)
+    fn help(&self) -> Option<Cow<'_, str>> {
+        self.help.as_deref().map(Cow::Borrowed)
     }
 
-    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
-        self.note.as_deref().map(std::borrow::Cow::Borrowed)
+    fn note(&self) -> Option<Cow<'_, str>> {
+        self.note.as_deref().map(Cow::Borrowed)
     }
 
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
-        self.url.as_deref().map(std::borrow::Cow::Borrowed)
+    fn url(&self) -> Option<Cow<'_, str>> {
+        self.url.as_deref().map(Cow::Borrowed)
     }
 
     fn labels(&self) -> Labels {

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{MietteError, MietteSpanContents, SourceCode, SpanContents};
 
 /// Utility struct for when you have a regular [`SourceCode`] type that doesn't
@@ -59,7 +61,7 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
         let inner_contents =
             self.inner().read_span(span, context_lines_before, context_lines_after)?;
         let mut contents = MietteSpanContents::new_named(
-            std::borrow::Cow::Borrowed(self.name.as_str()),
+            Cow::Borrowed(self.name.as_str()),
             inner_contents.data(),
             *inner_contents.span(),
             inner_contents.line(),

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,6 +4,7 @@ traits that you can implement to get access to miette's (and related library's)
 full reporting and such features.
 */
 use std::{
+    borrow::Cow,
     fmt::{self, Display},
     fs,
     panic::Location,
@@ -23,7 +24,7 @@ pub trait Diagnostic: std::error::Error {
     /// in the toplevel crate's documentation for easy searching. Rust path
     /// format (`foo::bar::baz`) is recommended, but more classic codes like
     /// `E0123` or enums will work just fine.
-    fn code(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn code(&self) -> Option<Cow<'_, str>> {
         None
     }
 
@@ -38,20 +39,20 @@ pub trait Diagnostic: std::error::Error {
 
     /// Additional help text related to this `Diagnostic`. Do you have any
     /// advice for the poor soul who's just run into this issue?
-    fn help(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn help(&self) -> Option<Cow<'_, str>> {
         None
     }
 
     /// Supplementary context for this `Diagnostic`, separate from help text.
     /// Notes mirror rustc-style `= note:` lines and offer additional
     /// information when guidance (help) is insufficient.
-    fn note(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn note(&self) -> Option<Cow<'_, str>> {
         None
     }
 
     /// URL to visit for a more detailed explanation/help about this
     /// `Diagnostic`.
-    fn url(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn url(&self) -> Option<Cow<'_, str>> {
         None
     }
 
@@ -601,9 +602,9 @@ pub struct MietteSpanContents<'a> {
     // Number of line in this snippet.
     line_count: usize,
     // Optional filename
-    name: Option<std::borrow::Cow<'a, str>>,
+    name: Option<Cow<'a, str>>,
     // Optional language
-    language: Option<std::borrow::Cow<'a, str>>,
+    language: Option<Cow<'a, str>>,
 }
 
 impl<'a> MietteSpanContents<'a> {
@@ -620,7 +621,7 @@ impl<'a> MietteSpanContents<'a> {
 
     /// Make a new [`MietteSpanContents`] object, with a name for its 'file'.
     pub const fn new_named(
-        name: std::borrow::Cow<'a, str>,
+        name: Cow<'a, str>,
         data: &'a [u8],
         span: SourceSpan,
         line: usize,
@@ -640,7 +641,7 @@ impl<'a> MietteSpanContents<'a> {
 
     /// Sets the `language` for syntax highlighting.
     #[must_use]
-    pub fn with_language(mut self, language: impl Into<std::borrow::Cow<'a, str>>) -> Self {
+    pub fn with_language(mut self, language: impl Into<Cow<'a, str>>) -> Self {
         self.language = Some(language.into());
         self
     }


### PR DESCRIPTION
## Summary

The `Cow<str>` migrations (code/help/note/url, `MietteSpanContents` name/language) spelled out `std::borrow::Cow` at every use site. This adds `use std::borrow::Cow;` at the top of each affected module (`error.rs`, `protocol.rs`, `miette_diagnostic.rs`, `named_source.rs`, `eyreish/wrapper.rs`, `eyreish/context.rs`) and uses the short name, consistent with the rest of the codebase.

No functional change. Build, fmt, clippy, and all tests pass.