### PR TITLE
refactor: move long std/core paths to top-level imports

### DIFF
--- a/src/diagnostic_chain.rs
+++ b/src/diagnostic_chain.rs
@@ -2,6 +2,8 @@
 Iterate over error `.diagnostic_source()` chains.
 */
 
+use std::fmt;
+
 use crate::protocol::Diagnostic;
 
 /// Iterator of a chain of cause errors.
@@ -70,8 +72,8 @@ impl<'a> ErrorKind<'a> {
     }
 }
 
-impl std::fmt::Debug for ErrorKind<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for ErrorKind<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorKind::Diagnostic(d) => d.fmt(f),
             ErrorKind::StdError(e) => e.fmt(f),
@@ -79,8 +81,8 @@ impl std::fmt::Debug for ErrorKind<'_> {
     }
 }
 
-impl std::fmt::Display for ErrorKind<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for ErrorKind<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ErrorKind::Diagnostic(d) => d.fmt(f),
             ErrorKind::StdError(e) => e.fmt(f),

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,7 @@ Error enum for miette. Used by certain operations in the protocol.
 */
 #[derive(Debug, Error)]
 pub enum MietteError {
-    /// Wrapper around [`std::io::Error`]. This is returned when something went
+    /// Wrapper around [`io::Error`]. This is returned when something went
     /// wrong while reading a [`SourceCode`](crate::SourceCode).
     #[error(transparent)]
     IoError(#[from] io::Error),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{env, fmt};
 
 use crate::{
     GraphicalReportHandler, GraphicalTheme, NarratableReportHandler, ReportHandler,
@@ -277,7 +277,7 @@ impl MietteHandlerOpts {
             !force_narrated
         } else if let Some(force_graphical) = self.force_graphical {
             force_graphical
-        } else if let Ok(env) = std::env::var("NO_GRAPHICS") {
+        } else if let Ok(env) = env::var("NO_GRAPHICS") {
             env == "0"
         } else {
             true

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -1,7 +1,9 @@
 use std::{
     borrow::Cow,
+    cmp::max,
     fmt::{self, Write},
-    io::IsTerminal,
+    io::{self, IsTerminal},
+    str::{CharIndices, from_utf8},
 };
 
 use owo_colors::{OwoColorize, Style};
@@ -63,7 +65,7 @@ impl GraphicalReportHandler {
     /// Create a new `GraphicalReportHandler` with the default
     /// [`GraphicalTheme`]. This will use both unicode characters and colors.
     pub fn new() -> Self {
-        let is_terminal = std::io::stdout().is_terminal() && std::io::stderr().is_terminal();
+        let is_terminal = io::stdout().is_terminal() && io::stderr().is_terminal();
         Self {
             links: if is_terminal { LinkStyle::Link } else { LinkStyle::Text },
             termwidth: 400,
@@ -492,7 +494,7 @@ impl GraphicalReportHandler {
                 // The snippets will overlap, so we create one Big Chunky Boi
                 let left_end = left.offset() + left.len();
                 let right_end = right.offset() + right.len();
-                let new_end = std::cmp::max(left_end, right_end);
+                let new_end = max(left_end, right_end);
 
                 let new_span = LabeledSpan::new(
                     left.label().map(String::from),
@@ -557,7 +559,7 @@ impl GraphicalReportHandler {
                     num_highlights += 1;
                 }
             }
-            max_gutter = std::cmp::max(max_gutter, num_highlights);
+            max_gutter = max(max_gutter, num_highlights);
         }
 
         // Oh and one more thing: We need to figure out how much room our line
@@ -946,7 +948,7 @@ impl GraphicalReportHandler {
     ) -> impl Iterator<Item = usize> + 'a + use<'a> {
         // Custom iterator that handles both ASCII and Unicode efficiently
         struct CharWidthIterator<'a> {
-            chars: std::str::CharIndices<'a>,
+            chars: CharIndices<'a>,
             grapheme_boundaries: Option<Vec<(usize, usize)>>, // (byte_pos, width) - None for ASCII
             current_grapheme_idx: usize,
             column: usize,
@@ -1114,7 +1116,7 @@ impl GraphicalReportHandler {
                     )
                     .style(hl.style)
                 );
-                highest = std::cmp::max(highest, end);
+                highest = max(highest, end);
 
                 (hl, vbar_offset)
             })
@@ -1245,7 +1247,7 @@ impl GraphicalReportHandler {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;
-        let context = std::str::from_utf8(context_data.data()).expect("Bad utf8 detected");
+        let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
         // Byte offset into the original source.

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::{fmt, str::from_utf8};
 
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -285,7 +285,7 @@ impl NarratableReportHandler {
         let context_data = source
             .read_span(context_span, self.context_lines, self.context_lines)
             .map_err(|_| fmt::Error)?;
-        let context = std::str::from_utf8(context_data.data()).expect("Bad utf8 detected");
+        let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
         let mut offset = context_data.span().offset() as usize;

--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -1,4 +1,7 @@
-use std::{env, io::IsTerminal};
+use std::{
+    env,
+    io::{self, IsTerminal},
+};
 
 use owo_colors::Style;
 
@@ -31,10 +34,8 @@ impl Default for GraphicalTheme {
         if force_color() {
             return Self::unicode();
         }
-        match std::env::var("NO_COLOR") {
-            _ if !std::io::stdout().is_terminal() || !std::io::stderr().is_terminal() => {
-                Self::none()
-            }
+        match env::var("NO_COLOR") {
+            _ if !io::stdout().is_terminal() || !io::stderr().is_terminal() => Self::none(),
             Ok(string) if string != "0" => Self::unicode_nocolor(),
             _ => Self::unicode(),
         }
@@ -46,7 +47,7 @@ impl GraphicalTheme {
         if force_color() {
             return Self::unicode();
         }
-        match std::env::var("NO_COLOR") {
+        match env::var("NO_COLOR") {
             _ if !is_terminal => Self::none(),
             Ok(string) if string != "0" => Self::unicode_nocolor(),
             _ => Self::unicode(),

--- a/src/macro_helpers.rs
+++ b/src/macro_helpers.rs
@@ -1,3 +1,5 @@
+use core::marker::PhantomData;
+
 use crate::protocol::{LabeledSpan, SourceSpan};
 
 // Huge thanks to @jam1gamer for this hack:
@@ -9,11 +11,11 @@ impl<T> IsOption for Option<T> {}
 
 #[doc(hidden)]
 #[derive(Debug, Default)]
-pub struct OptionalWrapper<T>(pub core::marker::PhantomData<T>);
+pub struct OptionalWrapper<T>(pub PhantomData<T>);
 
 impl<T> OptionalWrapper<T> {
     pub fn new() -> Self {
-        Self(core::marker::PhantomData)
+        Self(PhantomData)
     }
 }
 

--- a/src/miette_diagnostic.rs
+++ b/src/miette_diagnostic.rs
@@ -1,7 +1,10 @@
 use std::{
     borrow::Cow,
     error::Error,
-    fmt::{Debug, Display},
+    fmt::{self, Debug, Display},
+    mem,
+    ops::{Deref, DerefMut},
+    slice::{Iter, IterMut},
 };
 
 #[cfg(feature = "serde")]
@@ -102,7 +105,7 @@ impl Labels {
             labels.push(label);
             return;
         }
-        *self = match std::mem::take(self) {
+        *self = match mem::take(self) {
             Labels::None => Labels::One([label]),
             Labels::One([a]) => Labels::Two([a, label]),
             Labels::Two([a, b]) => Labels::Many(vec![a, b, label]),
@@ -111,7 +114,7 @@ impl Labels {
     }
 }
 
-impl std::ops::Deref for Labels {
+impl Deref for Labels {
     type Target = [LabeledSpan];
 
     fn deref(&self) -> &Self::Target {
@@ -119,7 +122,7 @@ impl std::ops::Deref for Labels {
     }
 }
 
-impl std::ops::DerefMut for Labels {
+impl DerefMut for Labels {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_mut_slice()
     }
@@ -127,7 +130,7 @@ impl std::ops::DerefMut for Labels {
 
 impl<'a> IntoIterator for &'a Labels {
     type Item = &'a LabeledSpan;
-    type IntoIter = std::slice::Iter<'a, LabeledSpan>;
+    type IntoIter = Iter<'a, LabeledSpan>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.as_slice().iter()
@@ -136,7 +139,7 @@ impl<'a> IntoIterator for &'a Labels {
 
 impl<'a> IntoIterator for &'a mut Labels {
     type Item = &'a mut LabeledSpan;
-    type IntoIter = std::slice::IterMut<'a, LabeledSpan>;
+    type IntoIter = IterMut<'a, LabeledSpan>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.as_mut_slice().iter_mut()
@@ -226,7 +229,7 @@ impl<'de> Deserialize<'de> for Labels {
 }
 
 impl Display for MietteDiagnostic {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", &self.message)
     }
 }

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt};
 
 use crate::{MietteError, MietteSpanContents, SourceCode, SpanContents};
 
@@ -12,8 +12,8 @@ pub struct NamedSource<S: SourceCode + 'static> {
     language: Option<String>,
 }
 
-impl<S: SourceCode> std::fmt::Debug for NamedSource<S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<S: SourceCode> fmt::Debug for NamedSource<S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("NamedSource")
             .field("name", &self.name)
             .field("source", &"<redacted>")

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,3 +1,5 @@
+use std::{env, fmt::Write, mem::size_of, panic::set_hook};
+
 use backtrace::Backtrace;
 use thiserror::Error;
 
@@ -5,7 +7,7 @@ use crate::{self as miette, Context, Diagnostic, Result};
 
 /// Tells miette to render panics using its rendering engine.
 pub fn set_panic_hook() {
-    std::panic::set_hook(Box::new(move |info| {
+    set_hook(Box::new(move |info| {
         let mut message = "Something went wrong".to_string();
         let payload = info.payload();
         if let Some(msg) = payload.downcast_ref::<&str>() {
@@ -32,10 +34,10 @@ struct Panic(String);
 
 impl Panic {
     fn backtrace() -> String {
-        use std::fmt::Write;
-        if let Ok(var) = std::env::var("RUST_BACKTRACE") {
+        use Write;
+        if let Ok(var) = env::var("RUST_BACKTRACE") {
             if !var.is_empty() && var != "0" {
-                const HEX_WIDTH: usize = std::mem::size_of::<usize>() + 2;
+                const HEX_WIDTH: usize = size_of::<usize>() + 2;
                 // Padding for next lines after frame's address
                 const NEXT_SYMBOL_PADDING: usize = HEX_WIDTH + 6;
                 let mut backtrace = String::new();

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -4,9 +4,11 @@ traits that you can implement to get access to miette's (and related library's)
 full reporting and such features.
 */
 use std::{
-    borrow::Cow,
+    borrow::{Borrow, Cow},
+    error::Error,
     fmt::{self, Display},
-    fs,
+    fs, mem,
+    ops::{Deref, Range},
     panic::Location,
 };
 
@@ -18,7 +20,7 @@ use crate::MietteError;
 /// Adds rich metadata to your Error that can be used by
 /// [`Report`](crate::Report) to print really nice and human-friendly error
 /// messages.
-pub trait Diagnostic: std::error::Error {
+pub trait Diagnostic: Error {
     /// Unique diagnostic code that can be used to look up more information
     /// about this `Diagnostic`. Ideally also globally unique, and documented
     /// in the toplevel crate's documentation for easy searching. Rust path
@@ -132,7 +134,7 @@ impl<'a> Related<'a> {
             items.push(related);
             return;
         }
-        *self = match std::mem::take(self) {
+        *self = match mem::take(self) {
             Related::None => Related::One([related]),
             Related::One([a]) => Related::Two([a, related]),
             Related::Two([a, b]) => Related::Many(vec![a, b, related]),
@@ -141,7 +143,7 @@ impl<'a> Related<'a> {
     }
 }
 
-impl<'a> std::ops::Deref for Related<'a> {
+impl<'a> Deref for Related<'a> {
     type Target = [&'a dyn Diagnostic];
 
     fn deref(&self) -> &Self::Target {
@@ -184,12 +186,12 @@ impl<'a> FromIterator<&'a dyn Diagnostic> for Related<'a> {
 macro_rules! box_error_impls {
     ($($box_type:ty),*) => {
         $(
-            impl std::error::Error for $box_type {
-                fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            impl Error for $box_type {
+                fn source(&self) -> Option<&(dyn Error + 'static)> {
                     (**self).source()
                 }
 
-                fn cause(&self) -> Option<&dyn std::error::Error> {
+                fn cause(&self) -> Option<&dyn Error> {
                     self.source()
                 }
             }
@@ -206,7 +208,7 @@ box_error_impls! {
 macro_rules! box_borrow_impls {
     ($($box_type:ty),*) => {
         $(
-            impl std::borrow::Borrow<dyn Diagnostic> for $box_type {
+            impl Borrow<dyn Diagnostic> for $box_type {
                 fn borrow(&self) -> &(dyn Diagnostic + 'static) {
                     self.as_ref()
                 }
@@ -264,7 +266,7 @@ impl From<String> for Box<dyn Diagnostic + Send + Sync> {
     fn from(s: String) -> Self {
         struct StringError(String);
 
-        impl std::error::Error for StringError {}
+        impl Error for StringError {}
         impl Diagnostic for StringError {}
 
         impl Display for StringError {
@@ -284,11 +286,11 @@ impl From<String> for Box<dyn Diagnostic + Send + Sync> {
     }
 }
 
-impl From<Box<dyn std::error::Error + Send + Sync>> for Box<dyn Diagnostic + Send + Sync> {
-    fn from(s: Box<dyn std::error::Error + Send + Sync>) -> Self {
+impl From<Box<dyn Error + Send + Sync>> for Box<dyn Diagnostic + Send + Sync> {
+    fn from(s: Box<dyn Error + Send + Sync>) -> Self {
         #[derive(thiserror::Error)]
         #[error(transparent)]
-        struct BoxedDiagnostic(Box<dyn std::error::Error + Send + Sync>);
+        struct BoxedDiagnostic(Box<dyn Error + Send + Sync>);
         impl fmt::Debug for BoxedDiagnostic {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 fmt::Debug::fmt(&self.0, f)
@@ -722,8 +724,8 @@ impl From<(SourceOffset, u32)> for SourceSpan {
     }
 }
 
-impl From<std::ops::Range<ByteOffset>> for SourceSpan {
-    fn from(range: std::ops::Range<ByteOffset>) -> Self {
+impl From<Range<ByteOffset>> for SourceSpan {
+    fn from(range: Range<ByteOffset>) -> Self {
         // `Range::len` returns `0` for empty/reversed ranges, matching the
         // previous behavior and avoiding underflow.
         Self { offset: range.start.into(), length: range.len() as u32 }

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -1,6 +1,8 @@
 /*!
 Default trait implementations for [`SourceCode`].
 */
+#[cfg(test)]
+use std::str::from_utf8;
 use std::{borrow::Cow, collections::VecDeque, fmt::Debug, sync::Arc};
 
 use crate::{MietteError, MietteSpanContents, SourceCode, SourceSpan};
@@ -207,7 +209,7 @@ mod tests {
     fn basic() -> Result<(), MietteError> {
         let src = String::from("foo\n");
         let contents = src.read_span(&(0, 4).into(), 0, 0)?;
-        assert_eq!("foo\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("foo\n", from_utf8(contents.data()).unwrap());
         assert_eq!(0, contents.line());
         assert_eq!(0, contents.column());
         Ok(())
@@ -217,7 +219,7 @@ mod tests {
     fn shifted() -> Result<(), MietteError> {
         let src = String::from("foobar");
         let contents = src.read_span(&(3, 3).into(), 1, 1)?;
-        assert_eq!("foobar", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("foobar", from_utf8(contents.data()).unwrap());
         assert_eq!(0, contents.line());
         assert_eq!(0, contents.column());
         Ok(())
@@ -227,7 +229,7 @@ mod tests {
     fn middle() -> Result<(), MietteError> {
         let src = String::from("foo\nbar\nbaz\n");
         let contents = src.read_span(&(4, 4).into(), 0, 0)?;
-        assert_eq!("bar\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("bar\n", from_utf8(contents.data()).unwrap());
         assert_eq!(1, contents.line());
         assert_eq!(0, contents.column());
         Ok(())
@@ -237,7 +239,7 @@ mod tests {
     fn middle_of_line() -> Result<(), MietteError> {
         let src = String::from("foo\nbarbar\nbaz\n");
         let contents = src.read_span(&(7, 4).into(), 0, 0)?;
-        assert_eq!("bar\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("bar\n", from_utf8(contents.data()).unwrap());
         assert_eq!(1, contents.line());
         assert_eq!(3, contents.column());
         Ok(())
@@ -247,7 +249,7 @@ mod tests {
     fn with_crlf() -> Result<(), MietteError> {
         let src = String::from("foo\r\nbar\r\nbaz\r\n");
         let contents = src.read_span(&(5, 5).into(), 0, 0)?;
-        assert_eq!("bar\r\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("bar\r\n", from_utf8(contents.data()).unwrap());
         assert_eq!(1, contents.line());
         assert_eq!(0, contents.column());
         Ok(())
@@ -257,7 +259,7 @@ mod tests {
     fn with_context() -> Result<(), MietteError> {
         let src = String::from("xxx\nfoo\nbar\nbaz\n\nyyy\n");
         let contents = src.read_span(&(8, 3).into(), 1, 1)?;
-        assert_eq!("foo\nbar\nbaz\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("foo\nbar\nbaz\n", from_utf8(contents.data()).unwrap());
         assert_eq!(1, contents.line());
         assert_eq!(0, contents.column());
         Ok(())
@@ -267,7 +269,7 @@ mod tests {
     fn multiline_with_context() -> Result<(), MietteError> {
         let src = String::from("aaa\nxxx\n\nfoo\nbar\nbaz\n\nyyy\nbbb\n");
         let contents = src.read_span(&(9, 11).into(), 1, 1)?;
-        assert_eq!("\nfoo\nbar\nbaz\n\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("\nfoo\nbar\nbaz\n\n", from_utf8(contents.data()).unwrap());
         assert_eq!(2, contents.line());
         assert_eq!(0, contents.column());
         let span: SourceSpan = (8, 14).into();
@@ -279,7 +281,7 @@ mod tests {
     fn multiline_with_context_line_start() -> Result<(), MietteError> {
         let src = String::from("one\ntwo\n\nthree\nfour\nfive\n\nsix\nseven\n");
         let contents = src.read_span(&(2, 0).into(), 2, 2)?;
-        assert_eq!("one\ntwo\n\n", std::str::from_utf8(contents.data()).unwrap());
+        assert_eq!("one\ntwo\n\n", from_utf8(contents.data()).unwrap());
         assert_eq!(0, contents.line());
         assert_eq!(0, contents.column());
         let span: SourceSpan = (0, 9).into();


### PR DESCRIPTION
## Summary

Replaces inline `std::…`/`core::…` fully-qualified paths with top-level `use` imports across the crate's own modules: `protocol`, `miette_diagnostic`, `error`, `named_source`, `source_impls`, `diagnostic_chain`, `panic`, `handler`, `macro_helpers`, and `handlers/*`.

No functional change — build, fmt, clippy, lib/doc/fancy tests all pass.

## Deliberately left fully-qualified

A few paths must stay qualified because importing them is incorrect or changes semantics:

- **`std::error::Error`** where it appears only as a `dyn` type alongside `.source()` calls (e.g. `diagnostic_chain.rs`): importing the `Error` trait changes method resolution and produces a lifetime error.
- **The `eyreish/` module**: its exported `macro_rules!` (`diagnostic!`, `ensure!`, …) require full `std::`/`$crate::` paths for hygiene when expanded in downstream crates, and `core::result::Result` is used inline specifically to disambiguate from miette's own `Result` alias. Rewriting these would break the macros / shadow `Result`.