### PR TITLE
ci: use latest rust toolchain, drop stale 1.70.0 matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
     strategy:
       matrix:
         features: [fancy]
-        rust: [1.70.0, stable]
         os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
@@ -48,11 +47,7 @@ jobs:
       - name: Clippy
         run: cargo clippy --all -- -D warnings
       - name: Run tests
-        if: matrix.rust == 'stable'
         run: cargo test --all --verbose --features ${{matrix.features}}
-      - name: Run tests
-        if: matrix.rust == '1.70.0'
-        run: cargo test --all --verbose --features ${{matrix.features}} no-format-args-capture
 
   wasm:
     name: Check Wasm build


### PR DESCRIPTION
Use the latest Rust pinned in `rust-toolchain.toml` (1.96.0) via `oxc-project/setup-rust`, same as the main oxc repo.

- Remove the `rust: [1.70.0, stable]` matrix axis from `build_and_test`. It was stale: the crate MSRV is now 1.85.0, and `matrix.rust` was never passed to `setup-rust`, so the installed toolchain always came from `rust-toolchain.toml` regardless of the matrix value.
- Collapse the two conditional test steps (the 1.70.0 one used the extra `no-format-args-capture` feature) into a single `cargo test` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)