### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+avoid-breaking-exported-api = false

--- a/src/macro_helpers.rs
+++ b/src/macro_helpers.rs
@@ -30,6 +30,7 @@ where
     T: IsOption,
 {
     #[doc(hidden)]
+    #[allow(clippy::wrong_self_convention)]
     pub fn to_option(self, value: &T) -> &T {
         value
     }

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1,5 +1,4 @@
 #![cfg(all(feature = "fancy-no-backtrace", not(miri)))]
-#![expect(unused_assignments)]
 
 use miette::{
     Diagnostic, GraphicalReportHandler, GraphicalTheme, MietteError, NamedSource,

--- a/tests/test_note.rs
+++ b/tests/test_note.rs
@@ -142,8 +142,6 @@ mod miette_diagnostic_tests {
     #[test]
     #[cfg(feature = "serde")]
     fn note_serializes_to_json() {
-        use serde_json::json;
-
         let diag = MietteDiagnostic::new("message").with_note("note text");
         let json = serde_json::to_value(&diag).unwrap();
 
@@ -154,8 +152,6 @@ mod miette_diagnostic_tests {
     #[test]
     #[cfg(feature = "serde")]
     fn note_absent_skips_in_serde() {
-        use serde_json::json;
-
         let diag = MietteDiagnostic::new("message");
         let json = serde_json::to_value(&diag).unwrap();
 


### PR DESCRIPTION
Ensures clippy is clean with `avoid-breaking-exported-api = false`.

Validated with `cargo clippy --workspace --all-targets --all-features`.
