### PR TITLE
perf: speed up read_span with bulk memchr line scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "indenter",
  "insta",
  "lazy_static",
+ "memchr",
  "owo-colors",
  "oxc-miette-derive",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 owo-colors = { version = "4", optional = true }
 cfg-if = "1"
 
+memchr = "2"
 unicode-width = "0.2.0"
 unicode-segmentation = "1.12.0"
 

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -15,16 +15,46 @@ fn context_info<'a>(
 ) -> Result<MietteSpanContents<'a>, MietteError> {
     let span_offset = span.offset() as usize;
     let span_len = span.len() as usize;
-    let mut offset = 0usize;
     let mut line_count = 0usize;
     let mut start_line = 0usize;
-    let mut start_column = 0usize;
     let mut before_lines_starts = VecDeque::new();
     let mut current_line_start = 0usize;
     let mut end_lines = 0usize;
     let mut post_span = false;
     let mut post_span_got_newline = false;
-    let mut iter = input.iter().copied().peekable();
+
+    // The byte-by-byte loop below only needs to run from just before the
+    // span to the end of the trailing context: bytes strictly before
+    // `span_offset - 1` can only exercise its "before the span" branches,
+    // so that region is scanned in bulk with memchr instead. `cut` is
+    // adjusted so a CRLF pair is never split across the boundary.
+    let mut cut = span_offset.saturating_sub(1).min(input.len());
+    if cut > 0 && input[cut - 1] == b'\r' {
+        cut -= 1;
+    }
+    let mut skip_lf_at = usize::MAX;
+    for pos in memchr::memchr2_iter(b'\r', b'\n', &input[..cut]) {
+        if pos == skip_lf_at {
+            continue;
+        }
+        // A CRLF pair counts as a single line break, ending at the `\n`.
+        let mut line_end = pos;
+        if input[pos] == b'\r' && pos + 1 < cut && input[pos + 1] == b'\n' {
+            line_end = pos + 1;
+            skip_lf_at = pos + 1;
+        }
+        line_count += 1;
+        before_lines_starts.push_back(current_line_start);
+        if before_lines_starts.len() > context_lines_before {
+            start_line += 1;
+            before_lines_starts.pop_front();
+        }
+        current_line_start = line_end + 1;
+    }
+    // `current_line_start..cut` contains no line breaks.
+    let mut start_column = cut - current_line_start;
+    let mut offset = cut;
+    let mut iter = input[cut..].iter().copied().peekable();
     while let Some(char) = iter.next() {
         if matches!(char, b'\r' | b'\n') {
             line_count += 1;
@@ -77,6 +107,11 @@ fn context_info<'a>(
             .front()
             .copied()
             .unwrap_or(if context_lines_before == 0 { span_offset } else { 0 });
+        // A zero-length span starting just past the end of the input passes
+        // the check above but has no content to slice.
+        if starting_offset > offset {
+            return Err(MietteError::OutOfBounds);
+        }
         Ok(MietteSpanContents::new(
             &input[starting_offset..offset],
             (starting_offset as u32, (offset - starting_offset) as u32).into(),
@@ -275,6 +310,16 @@ mod tests {
         let span: SourceSpan = (8, 14).into();
         assert_eq!(&span, contents.span());
         Ok(())
+    }
+
+    #[test]
+    fn zero_length_span_just_past_eof() {
+        // Used to panic with a slice out-of-range instead of returning an
+        // error (found by differential fuzzing).
+        let src = String::from("a");
+        assert!(matches!(src.read_span(&(2, 0).into(), 0, 0), Err(MietteError::OutOfBounds)));
+        let src = String::new();
+        assert!(matches!(src.read_span(&(1, 0).into(), 0, 0), Err(MietteError::OutOfBounds)));
     }
 
     #[test]

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -32,17 +32,17 @@ fn context_info<'a>(
     if cut > 0 && input[cut - 1] == b'\r' {
         cut -= 1;
     }
-    let mut skip_lf_at = usize::MAX;
     for pos in memchr::memchr2_iter(b'\r', b'\n', &input[..cut]) {
-        if pos == skip_lf_at {
+        // Skip the `\n` of a CRLF pair already counted at its `\r`.
+        if input[pos] == b'\n' && pos > 0 && input[pos - 1] == b'\r' {
             continue;
         }
         // A CRLF pair counts as a single line break, ending at the `\n`.
-        let mut line_end = pos;
-        if input[pos] == b'\r' && pos + 1 < cut && input[pos + 1] == b'\n' {
-            line_end = pos + 1;
-            skip_lf_at = pos + 1;
-        }
+        let line_end = if input[pos] == b'\r' && pos + 1 < cut && input[pos + 1] == b'\n' {
+            pos + 1
+        } else {
+            pos
+        };
         line_count += 1;
         before_lines_starts.push_back(current_line_start);
         if before_lines_starts.len() > context_lines_before {


### PR DESCRIPTION
TL;DR miette was going one-byte-at-a-time through the file from its start to where the diagnostic was in order to grab the code to render. With this PR, we just go to each line ending in the file and skip the bytes in between, until we get to the one we want. So we do less work.

AI Disclosure: Generated with Claude Code, Fable 5 + Opus 4.8. Reviewed and tested by me.

## Summary

`context_info` (the engine behind every built-in `SourceCode::read_span` impl) walked the source byte-at-a-time from offset 0 for every call. This PR scans the region before the span in bulk with `memchr2` instead, deriving line count, context line starts, and column arithmetically from newline positions. The original byte-loop is kept verbatim for the span itself and the trailing context, so behavior is unchanged.

It also fixes a panic found while validating the change: a zero-length span starting exactly one byte past EOF (`"a".read_span(&(2, 0).into(), 0, 0)`) sliced out of bounds instead of returning `Err(MietteError::OutOfBounds)`. This was reachable from `GraphicalReportHandler`, which calls `read_span(label, 0, 0)` on the primary label, so an off-by-one zero-length label span could panic report rendering. A regression test is included.

`memchr` moves from transitive to direct dependency.

## Performance

Measured with a benchmark (minimum per-call across 9 rounds, `--release`), reading a 10-byte span near EOF with 1 line of context before/after. `main` vs this branch:

**Large file (40k lines, ~3 MB):**

| Line endings | main | this branch | speedup |
| --- | --- | --- | --- |
| LF | 2084 µs | 257 µs | 8.1x |
| CRLF | 2112 µs | 454 µs | 4.7x |

**Small file (20 lines, ~1.5 KB):**

| Line endings | main | this branch | speedup |
| --- | --- | --- | --- |
| LF | 1.02 µs | 0.21 µs | 4.8x |
| CRLF | 0.95 µs | 0.30 µs | 3.2x |

The speedup ratio is driven by the pre-span scan and holds at both file sizes; the absolute win only matters for large sources, where per-call cost drops from ~2 ms to ~0.26 ms. Render cost previously scaled linearly with file size (full-file scans per rendered diagnostic); those scans are now ~8x cheaper. Heap usage is unchanged: one 32-byte `VecDeque` allocation per call at default context settings, independent of file size (verified with a counting allocator).

### Downstream impact (oxlint)

Built `oxlint` (release) against `main` of oxc-miette vs. this branch of oxc-miette — identical except for the version of the miette dependency — and measured full-directory lint runs with `hyperfine` (default rules, output to `/dev/null`). Since parse + analysis is byte-identical between the two binaries, the entire delta is `read_span`:

| Target | files | diagnostics | main | this branch | speedup |
| --- | --- | --- | --- | --- | --- |
| canvas-lms | ~10k | 3,149 | 370 ms | 224 ms | 1.65x |
| GitLab | ~10.7k | 1,824 | 579 ms | 438 ms | 1.32x |
| synthetic stress (2 MB file, 4,000 diagnostics) | 1 | 4,000 | 5.53 s | 1.01 s | 5.47x |

Real large codebases see a **1.3–1.65x end-to-end oxlint speedup** (~140 ms saved per run) because they emit thousands of rendered diagnostics, each of which previously re-scanned the whole file. The synthetic case shows the ceiling for diagnostic-heavy runs on large sources. Baseline runs are also noticeably noisier (their per-diagnostic cost scales with span offset); the patched runs are flat.

## Verification

- Differential-fuzzed the new implementation against the old one: **309,698 cases** (random content with LF/CRLF/lone-CR mixes, random spans including zero-length and out-of-bounds, context settings 0–3) with **0 mismatches**; the 68 cases where the old code panics now return `Err(OutOfBounds)`.
- Full test suite passes including the 38 graphical golden-output tests (the `color_format` failures are pre-existing/environmental — they fail identically on `main` in a non-tty sandbox).
- Ran the real downstream consumer against this branch: patched [oxc](https://github.com/oxc-project/oxc)'s `oxc-miette` dependency to this branch and ran `oxc_linter`'s full snapshot suite (820 golden files, each rendered through `GraphicalReportHandler` → `read_span`). All pass with **0 changes** — byte-identical diagnostic output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
