### PR TITLE
perf: reuse span contents in render_context instead of re-reading

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -506,7 +506,6 @@ impl GraphicalReportHandler {
                     source.read_span(new_span.inner(), self.context_lines, self.context_lines)
                 {
                     contexts.pop();
-                    // We'll throw the contents away later
                     contexts.push((Cow::Owned(new_span), new_conts));
                     continue;
                 }
@@ -514,8 +513,8 @@ impl GraphicalReportHandler {
 
             contexts.push((Cow::Borrowed(right), right_conts));
         }
-        for (ctx, _) in contexts {
-            self.render_context(f, source, &ctx, &labels[..])?;
+        for (ctx, conts) in contexts {
+            self.render_context(f, source, &ctx, conts, &labels[..])?;
         }
 
         Ok(())
@@ -526,9 +525,10 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         source: &dyn SourceCode,
         context: &LabeledSpan,
+        contents: MietteSpanContents<'_>,
         labels: &[LabeledSpan],
     ) -> fmt::Result {
-        let (contents, lines) = self.get_lines(source, context.inner())?;
+        let lines = self.get_lines(&contents);
 
         // only consider labels from the context as primary label
         let ctx_labels = labels.iter().filter(|l| {
@@ -1239,14 +1239,11 @@ impl GraphicalReportHandler {
         Ok(())
     }
 
-    fn get_lines<'a>(
-        &'a self,
-        source: &'a dyn SourceCode,
-        context_span: &'a SourceSpan,
-    ) -> Result<(MietteSpanContents<'a>, Vec<Line<'a>>), fmt::Error> {
-        let context_data = source
-            .read_span(context_span, self.context_lines, self.context_lines)
-            .map_err(|_| fmt::Error)?;
+    /// Splits already-read span contents into [`Line`]s. Takes the contents
+    /// produced by the `read_span` call in [`Self::render_snippets`] so the
+    /// span doesn't have to be re-read (each read is a scan of the source up
+    /// to the span).
+    fn get_lines<'a>(&self, context_data: &MietteSpanContents<'a>) -> Vec<Line<'a>> {
         let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
@@ -1305,7 +1302,7 @@ impl GraphicalReportHandler {
                 line_offset = offset;
             }
         }
-        Ok((context_data, lines))
+        lines
     }
 }
 

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -3,8 +3,7 @@ use std::{fmt, str::from_utf8};
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{
-    LabeledSpan, MietteError, MietteSpanContents, ReportHandler, SourceCode, SourceSpan,
-    SpanContents,
+    LabeledSpan, MietteSpanContents, ReportHandler, SourceCode, SourceSpan, SpanContents,
     diagnostic_chain::DiagnosticChain,
     protocol::{Diagnostic, Severity},
 };
@@ -165,57 +164,50 @@ impl NarratableReportHandler {
                 let mut labels = diagnostic.labels();
                 labels.sort_unstable_by_key(|l| l.inner().offset());
                 if !labels.is_empty() {
-                    let contents = labels
-                        .iter()
-                        .map(|label| {
-                            source.read_span(label.inner(), self.context_lines, self.context_lines)
-                        })
-                        .collect::<Result<Vec<MietteSpanContents<'_>>, MietteError>>()
-                        .map_err(|_| fmt::Error)?;
-                    let mut contexts = Vec::new();
-                    for (right, right_conts) in labels.iter().cloned().zip(contents.iter()) {
+                    let mut contexts: Vec<(LabeledSpan, MietteSpanContents<'_>)> =
+                        Vec::with_capacity(labels.len());
+                    for right in labels.iter() {
+                        let right_conts = source
+                            .read_span(right.inner(), self.context_lines, self.context_lines)
+                            .map_err(|_| fmt::Error)?;
+
                         if contexts.is_empty() {
-                            contexts.push((right, right_conts));
-                        } else {
-                            let (left, left_conts) = contexts.last().unwrap().clone();
+                            contexts.push((right.clone(), right_conts));
+                            continue;
+                        }
+
+                        let (left, left_conts) = contexts.last().unwrap();
+                        if left_conts.line() + left_conts.line_count() >= right_conts.line() {
+                            // The snippets will overlap, so we create one Big Chunky Boi
                             let left_end = left.offset() + left.len();
                             let right_end = right.offset() + right.len();
-                            if left_conts.line() + left_conts.line_count() >= right_conts.line() {
-                                // The snippets will overlap, so we create one Big Chunky Boi
-                                let new_span = LabeledSpan::new(
-                                    left.label().map(String::from),
-                                    left.offset(),
-                                    if right_end >= left_end {
-                                        // Right end goes past left end
-                                        right_end - left.offset()
-                                    } else {
-                                        // right is contained inside left
-                                        left.len()
-                                    },
-                                );
-                                if source
-                                    .read_span(
-                                        new_span.inner(),
-                                        self.context_lines,
-                                        self.context_lines,
-                                    )
-                                    .is_ok()
-                                {
-                                    contexts.pop();
-                                    contexts.push((
-                                        new_span, // We'll throw this away later
-                                        left_conts,
-                                    ));
+                            let new_span = LabeledSpan::new(
+                                left.label().map(String::from),
+                                left.offset(),
+                                if right_end >= left_end {
+                                    // Right end goes past left end
+                                    right_end - left.offset()
                                 } else {
-                                    contexts.push((right, right_conts));
-                                }
-                            } else {
-                                contexts.push((right, right_conts));
+                                    // right is contained inside left
+                                    left.len()
+                                },
+                            );
+                            // Check that the two contexts can be combined
+                            if let Ok(new_conts) = source.read_span(
+                                new_span.inner(),
+                                self.context_lines,
+                                self.context_lines,
+                            ) {
+                                contexts.pop();
+                                contexts.push((new_span, new_conts));
+                                continue;
                             }
                         }
+
+                        contexts.push((right.clone(), right_conts));
                     }
-                    for (ctx, _) in contexts {
-                        self.render_context(f, source, &ctx, &labels[..])?;
+                    for (_, conts) in contexts {
+                        self.render_context(f, conts, &labels[..])?;
                     }
                 }
             }
@@ -226,11 +218,10 @@ impl NarratableReportHandler {
     fn render_context(
         &self,
         f: &mut impl fmt::Write,
-        source: &dyn SourceCode,
-        context: &LabeledSpan,
+        contents: MietteSpanContents<'_>,
         labels: &[LabeledSpan],
     ) -> fmt::Result {
-        let (contents, lines) = self.get_lines(source, context.inner())?;
+        let lines = self.get_lines(&contents);
         write!(f, "Begin snippet")?;
         if let Some(filename) = contents.name() {
             write!(f, " for {filename}")?;
@@ -277,14 +268,11 @@ impl NarratableReportHandler {
         Ok(())
     }
 
-    fn get_lines<'a>(
-        &'a self,
-        source: &'a dyn SourceCode,
-        context_span: &'a SourceSpan,
-    ) -> Result<(MietteSpanContents<'a>, Vec<Line<'a>>), fmt::Error> {
-        let context_data = source
-            .read_span(context_span, self.context_lines, self.context_lines)
-            .map_err(|_| fmt::Error)?;
+    /// Splits already-read span contents into [`Line`]s. Takes the contents
+    /// produced by the `read_span` call in [`Self::render_snippets`] so the
+    /// span doesn't have to be re-read (each read is a scan of the source up
+    /// to the span).
+    fn get_lines<'a>(&self, context_data: &MietteSpanContents<'a>) -> Vec<Line<'a>> {
         let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
         let mut column = context_data.column();
@@ -338,7 +326,7 @@ impl NarratableReportHandler {
                 line_offset = offset;
             }
         }
-        Ok((context_data, lines))
+        lines
     }
 }
 


### PR DESCRIPTION
Generated with Claude Code, Fable 5. Tested and reviewed by me.

## Summary

`render_snippets` already reads each context's span contents via `read_span`, but both the graphical and narratable handlers then discarded them: `render_context` called `get_lines`, which re-read the exact same span — and every `read_span` is a scan of the source up to the span offset. This PR passes the already-read `MietteSpanContents` into `render_context`, so each rendered context reads its span once.

In the narratable handler, the merge loop also performed a full merged-span read only to use it as an `is_ok()` check, storing the (never-rendered) left contents instead. It now keeps the merged read's result — exactly what `render_context` re-read on main — and its `render_context` drops the now-unused `source`/`context` parameters. The loop was restructured to mirror the graphical handler's, which also removes per-label `LabeledSpan` clones.

## Behavior

Rendered output is byte-identical: all graphical/narrated snapshot tests pass unchanged, and benchmark output sizes match main exactly.

## Benchmarks

Ad-hoc harness (linter-style: batch-rendering two-label diagnostics, release mode, medians of 30 runs, unicode-nocolor theme at width 120):

| Scenario | Handler | main | this PR | Change |
|---|---|---|---|---|
| 1 MiB source, 200 diagnostics | Graphical | 57.0 ms | 45.6 ms | ~20% faster |
| 1 MiB source, 200 diagnostics | Narratable | 45.0 ms | 33.7 ms | ~25% faster |
| 4 KiB source, 3 diagnostics ×2000 | Graphical | 33.6 ms | 31.2 ms | ~7% faster |
| 4 KiB source, 3 diagnostics ×2000 | Narratable | 11.0 ms | 8.5 ms | ~22% faster |

The gain scales with source size and span depth, since the eliminated work is a scan of the source up to each span; small files still improve because no work was added anywhere. However, it's ultimately a micro-optimization in most cases because you won't usually have thousands of diagnostics, or if you do they won't all be on extremely large files.

For oxc specifically, the graphical handler is what `oxc_diagnostics`/oxlint/oxfmt use; the narratable change benefits other consumers and keeps the two handlers structurally parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)