### PR TITLE
perf: derive primary-label line/column instead of a second read_span

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -514,7 +514,7 @@ impl GraphicalReportHandler {
             contexts.push((Cow::Borrowed(right), right_conts));
         }
         for (ctx, conts) in contexts {
-            self.render_context(f, source, &ctx, conts, &labels[..])?;
+            self.render_context(f, &ctx, conts, &labels[..])?;
         }
 
         Ok(())
@@ -523,7 +523,6 @@ impl GraphicalReportHandler {
     fn render_context(
         &self,
         f: &mut impl fmt::Write,
-        source: &dyn SourceCode,
         context: &LabeledSpan,
         contents: MietteSpanContents<'_>,
         labels: &[LabeledSpan],
@@ -581,34 +580,31 @@ impl GraphicalReportHandler {
             self.theme.characters.hbar,
         )?;
 
-        // If there is a primary label, then use its span
-        // as the reference point for line/column information.
-        let primary_contents = match primary_label {
-            Some(label) => source.read_span(label.inner(), 0, 0).map_err(|_| fmt::Error)?,
-            None => contents,
+        // The snippet header reports the primary label's line/column. Rather
+        // than issuing a second full `read_span` (which re-scans the source
+        // from byte 0 — as costly as the read that produced `contents`),
+        // derive them from `contents`: its data begins at a line boundary at
+        // line `contents.line()`, and the primary label always lies within it,
+        // so only the short prefix up to the label needs to be walked.
+        let (primary_line, primary_column) = match primary_label {
+            Some(label) => {
+                let base = contents.span().offset() as usize;
+                let rel = (label.inner().offset() as usize).saturating_sub(base);
+                line_column_at(contents.data(), contents.line(), contents.column(), rel)
+            }
+            None => (contents.line(), contents.column()),
         };
 
-        match primary_contents.name() {
+        match contents.name() {
             Some(source_name) => {
                 let source_name = source_name.style(self.theme.styles.link);
-                writeln!(
-                    f,
-                    "[{}:{}:{}]",
-                    source_name,
-                    primary_contents.line() + 1,
-                    primary_contents.column() + 1
-                )?;
+                writeln!(f, "[{}:{}:{}]", source_name, primary_line + 1, primary_column + 1)?;
             }
             _ => {
                 if lines.len() <= 1 {
                     writeln!(f, "{}", self.theme.characters.hbar.to_string().repeat(3))?;
                 } else {
-                    writeln!(
-                        f,
-                        "[{}:{}]",
-                        primary_contents.line() + 1,
-                        primary_contents.column() + 1
-                    )?;
+                    writeln!(f, "[{}:{}]", primary_line + 1, primary_column + 1)?;
                 }
             }
         }
@@ -1415,6 +1411,59 @@ fn split_label(v: &str, style: Style) -> Vec<String> {
     v.split('\n').map(|i| i.style(style).to_string()).collect()
 }
 
+/// Derive the 0-indexed line and column of the byte at `data[rel]` — a payload
+/// returned by [`SourceCode::read_span`] whose first byte sits at absolute line
+/// `base_line` / column `base_column`.
+///
+/// This exists to avoid a second full `read_span` (which re-scans the source
+/// from byte 0) just to locate a label that already lies inside `data`. It
+/// walks only the `data[..rel]` prefix and mirrors the newline handling in
+/// `source_impls::context_info` — a `\r\n` pair and a lone `\r` or `\n` each
+/// count as a single line break — so the result equals
+/// `read_span(&(base_offset + rel, 0).into(), 0, 0)`'s `line()`/`column()`.
+fn line_column_at(data: &[u8], base_line: usize, base_column: usize, rel: usize) -> (usize, usize) {
+    let mut rel = rel.min(data.len());
+    // An offset landing on the `\n` of a `\r\n` pair sits *inside* an unfinished
+    // line break: `context_info` has not yet advanced the line at that byte, so
+    // it reports the position of the preceding `\r`. Normalize to that byte so
+    // the prefix walk below agrees.
+    if rel > 0 && rel < data.len() && data[rel - 1] == b'\r' && data[rel] == b'\n' {
+        rel -= 1;
+    }
+    let mut line = base_line;
+    // Byte index just past the most recent line break, i.e. the start of the
+    // line that `rel` falls on. `None` until the first break is seen, meaning
+    // `rel` is still on `data`'s first line.
+    let mut line_start: Option<usize> = None;
+    let mut i = 0;
+    while i < rel {
+        match data[i] {
+            b'\n' => {
+                line += 1;
+                line_start = Some(i + 1);
+            }
+            b'\r' => {
+                line += 1;
+                // Pair `\r\n` into a single break only when the `\n` is within
+                // the walked prefix; a trailing `\r` counts as a lone break,
+                // matching `context_info` at the same offset.
+                if i + 1 < rel && data[i + 1] == b'\n' {
+                    i += 1;
+                }
+                line_start = Some(i + 1);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    match line_start {
+        // `rel` lies on a later line, which by definition starts at column 0.
+        Some(start) => (line, rel - start),
+        // Still on the first line, so offset from `data`'s starting column.
+        None => (line, base_column + rel),
+    }
+}
+
 impl FancySpan {
     fn new(label: Option<&str>, span: SourceSpan, style: Style) -> Self {
         FancySpan { label: label.map(|l| split_label(l, style)), span, style }
@@ -1434,5 +1483,86 @@ impl FancySpan {
 
     fn len(&self) -> usize {
         self.span.len() as usize
+    }
+}
+
+#[cfg(test)]
+mod line_column_tests {
+    use super::line_column_at;
+    use crate::{SourceCode, SpanContents};
+
+    /// Deterministic xorshift so any failure reproduces from a fixed seed.
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn below(&mut self, n: usize) -> usize {
+            (self.next() % n as u64) as usize
+        }
+    }
+
+    /// Assert `line_column_at` reproduces a real `read_span(&(off, 0), 0, 0)`
+    /// for an offset that falls inside a `read_span(&(off, len), ctx, ctx)`
+    /// payload — exactly how `render_context` consumes it. Returns whether a
+    /// case was actually checked (both reads in bounds).
+    fn check(src: &str, off: usize, len: usize, ctx: usize) -> bool {
+        let Ok(contents) = src.read_span(&(off as u32, len as u32).into(), ctx, ctx) else {
+            return false;
+        };
+        let base = contents.span().offset() as usize;
+        let rel = off.saturating_sub(base);
+        let got = line_column_at(contents.data(), contents.line(), contents.column(), rel);
+
+        // The context read succeeded, so the label is in bounds; deriving its
+        // position must never diverge from a direct zero-context read.
+        let expected = src
+            .read_span(&(off as u32, 0u32).into(), 0, 0)
+            .expect("in-bounds label must have a resolvable line/column");
+        assert_eq!(
+            got,
+            (expected.line(), expected.column()),
+            "mismatch for src={src:?} off={off} len={len} ctx={ctx}"
+        );
+        true
+    }
+
+    /// Exhaustively check every char-boundary offset of many small randomized
+    /// sources, across LF / CRLF / lone-CR and multibyte alphabets.
+    #[test]
+    fn matches_read_span_exhaustively() {
+        let alphabets: &[&[&str]] = &[
+            &["a", "\n"],
+            &["a", "b", "c", "\n"],
+            &["a", "b", "\r\n"],
+            &["a", "\r", "\n", "\r\n"],
+            &["x", "y", "\n", "é", "🦀", "\r\n"],
+        ];
+        let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
+        let mut checked = 0usize;
+        for alpha in alphabets {
+            for _ in 0..3000 {
+                let n = rng.below(14);
+                let mut s = String::new();
+                for _ in 0..n {
+                    s.push_str(alpha[rng.below(alpha.len())]);
+                }
+                for off in (0..=s.len()).filter(|&i| s.is_char_boundary(i)) {
+                    for ctx in 0..=2 {
+                        for &len in &[0usize, 1, 4] {
+                            if check(&s, off, len, ctx) {
+                                checked += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        assert!(checked > 100_000, "expected a broad sweep, only checked {checked}");
     }
 }

--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -591,6 +591,7 @@ impl GraphicalReportHandler {
                 let base = contents.span().offset() as usize;
                 let rel = (label.inner().offset() as usize).saturating_sub(base);
                 line_column_at(contents.data(), contents.line(), contents.column(), rel)
+                    .ok_or(fmt::Error)?
             }
             None => (contents.line(), contents.column()),
         };
@@ -1417,16 +1418,29 @@ fn split_label(v: &str, style: Style) -> Vec<String> {
 ///
 /// This exists to avoid a second full `read_span` (which re-scans the source
 /// from byte 0) just to locate a label that already lies inside `data`. It
-/// walks only the `data[..rel]` prefix and mirrors the newline handling in
-/// `source_impls::context_info` — a `\r\n` pair and a lone `\r` or `\n` each
-/// count as a single line break — so the result equals
-/// `read_span(&(base_offset + rel, 0).into(), 0, 0)`'s `line()`/`column()`.
-fn line_column_at(data: &[u8], base_line: usize, base_column: usize, rel: usize) -> (usize, usize) {
-    let mut rel = rel.min(data.len());
+/// scans only the `data[..rel]` prefix — with the same `memchr2` newline search
+/// `source_impls::context_info` uses, so a long (e.g. minified) line stays cheap
+/// — and mirrors its line-break handling (a `\r\n` pair and a lone `\r`/`\n`
+/// each count once). The result equals `read_span(&(base_offset + rel, 0).into(),
+/// 0, 0)`'s `line()`/`column()`, or `None` when that offset is out of bounds
+/// (`rel > data.len()`), which `read_span` reports as `OutOfBounds`.
+fn line_column_at(
+    data: &[u8],
+    base_line: usize,
+    base_column: usize,
+    rel: usize,
+) -> Option<(usize, usize)> {
+    // A label past the end of the payload is out of bounds; the caller treats
+    // this like the `OutOfBounds` the equivalent `read_span` would return,
+    // rather than clamping to a misleading end-of-snippet position.
+    if rel > data.len() {
+        return None;
+    }
+    let mut rel = rel;
     // An offset landing on the `\n` of a `\r\n` pair sits *inside* an unfinished
     // line break: `context_info` has not yet advanced the line at that byte, so
     // it reports the position of the preceding `\r`. Normalize to that byte so
-    // the prefix walk below agrees.
+    // the prefix scan below agrees.
     if rel > 0 && rel < data.len() && data[rel - 1] == b'\r' && data[rel] == b'\n' {
         rel -= 1;
     }
@@ -1435,33 +1449,26 @@ fn line_column_at(data: &[u8], base_line: usize, base_column: usize, rel: usize)
     // line that `rel` falls on. `None` until the first break is seen, meaning
     // `rel` is still on `data`'s first line.
     let mut line_start: Option<usize> = None;
-    let mut i = 0;
-    while i < rel {
-        match data[i] {
-            b'\n' => {
-                line += 1;
-                line_start = Some(i + 1);
-            }
-            b'\r' => {
-                line += 1;
-                // Pair `\r\n` into a single break only when the `\n` is within
-                // the walked prefix; a trailing `\r` counts as a lone break,
-                // matching `context_info` at the same offset.
-                if i + 1 < rel && data[i + 1] == b'\n' {
-                    i += 1;
-                }
-                line_start = Some(i + 1);
-            }
-            _ => {}
+    for pos in memchr::memchr2_iter(b'\r', b'\n', &data[..rel]) {
+        // Skip the `\n` of a `\r\n` pair already counted at its `\r`.
+        if data[pos] == b'\n' && pos > 0 && data[pos - 1] == b'\r' {
+            continue;
         }
-        i += 1;
+        line += 1;
+        // A `\r\n` pair is a single break ending at the `\n`.
+        let line_end = if data[pos] == b'\r' && pos + 1 < rel && data[pos + 1] == b'\n' {
+            pos + 1
+        } else {
+            pos
+        };
+        line_start = Some(line_end + 1);
     }
-    match line_start {
+    Some(match line_start {
         // `rel` lies on a later line, which by definition starts at column 0.
         Some(start) => (line, rel - start),
         // Still on the first line, so offset from `data`'s starting column.
         None => (line, base_column + rel),
-    }
+    })
 }
 
 impl FancySpan {
@@ -1507,10 +1514,12 @@ mod line_column_tests {
         }
     }
 
-    /// Assert `line_column_at` reproduces a real `read_span(&(off, 0), 0, 0)`
-    /// for an offset that falls inside a `read_span(&(off, len), ctx, ctx)`
-    /// payload — exactly how `render_context` consumes it. Returns whether a
-    /// case was actually checked (both reads in bounds).
+    /// Assert `line_column_at` matches a real `read_span(&(off, 0), 0, 0)` for an
+    /// offset inside a `read_span(&(off, len), ctx, ctx)` payload — exactly how
+    /// `render_context` consumes it. Full equivalence, *including* the error
+    /// case: `line_column_at` must return `None` iff the direct read is
+    /// `OutOfBounds` (a label past the snippet, e.g. `off == src.len() + 1`).
+    /// Returns whether a case was actually checked (the context read succeeded).
     fn check(src: &str, off: usize, len: usize, ctx: usize) -> bool {
         let Ok(contents) = src.read_span(&(off as u32, len as u32).into(), ctx, ctx) else {
             return false;
@@ -1519,21 +1528,23 @@ mod line_column_tests {
         let rel = off.saturating_sub(base);
         let got = line_column_at(contents.data(), contents.line(), contents.column(), rel);
 
-        // The context read succeeded, so the label is in bounds; deriving its
-        // position must never diverge from a direct zero-context read.
-        let expected = src
-            .read_span(&(off as u32, 0u32).into(), 0, 0)
-            .expect("in-bounds label must have a resolvable line/column");
-        assert_eq!(
-            got,
-            (expected.line(), expected.column()),
-            "mismatch for src={src:?} off={off} len={len} ctx={ctx}"
-        );
+        match src.read_span(&(off as u32, 0u32).into(), 0, 0) {
+            Ok(expected) => assert_eq!(
+                got,
+                Some((expected.line(), expected.column())),
+                "mismatch for src={src:?} off={off} len={len} ctx={ctx}"
+            ),
+            Err(_) => assert_eq!(
+                got, None,
+                "accepted an out-of-bounds label for src={src:?} off={off} len={len} ctx={ctx}"
+            ),
+        }
         true
     }
 
     /// Exhaustively check every char-boundary offset of many small randomized
-    /// sources, across LF / CRLF / lone-CR and multibyte alphabets.
+    /// sources — plus offsets one and two bytes past EOF — across LF / CRLF /
+    /// lone-CR and multibyte alphabets.
     #[test]
     fn matches_read_span_exhaustively() {
         let alphabets: &[&[&str]] = &[
@@ -1552,7 +1563,12 @@ mod line_column_tests {
                 for _ in 0..n {
                     s.push_str(alpha[rng.below(alpha.len())]);
                 }
-                for off in (0..=s.len()).filter(|&i| s.is_char_boundary(i)) {
+                // Include `len + 1` / `len + 2`, which are past EOF (never char
+                // boundaries) to exercise the out-of-bounds rejection.
+                for off in 0..=s.len() + 2 {
+                    if off <= s.len() && !s.is_char_boundary(off) {
+                        continue;
+                    }
                     for ctx in 0..=2 {
                         for &len in &[0usize, 1, 4] {
                             if check(&s, off, len, ctx) {


### PR DESCRIPTION
## Problem

For a single-label diagnostic, `GraphicalReportHandler::render_report` scans the source **twice** from byte 0 to the span:

1. `render_snippets` → `read_span(span, context_lines, context_lines)` — needed for the snippet text.
2. `render_context` → `read_span(primary_label, 0, 0)` — issued **only** to get the primary label's line/column for the `[name:line:col]` header.

`read_span` is O(offset), so on a large file this roughly doubled render cost — the arithmetic gives it away: `render(cal.com.ts) ≈ 731µs ≈ 2 × read_span(cal.com.ts) 344µs`.

## Fix

The primary label always lies inside the `contents` already read for the snippet (guaranteed by the label-in-context filter). So its line/column can be derived by scanning only the short prefix from the context start to the label, instead of rescanning the whole source. The prefix scan uses `memchr2` (the same primitive `context_info` uses), so it stays cheap even on a long / minified line, and its line-break handling mirrors `context_info` (a `\r\n` pair and a lone `\r`/`\n` each count once), so the header is byte-for-byte identical.

Out-of-bounds labels (offset past the payload) return `None` → `fmt::Error`, exactly matching the `OutOfBounds` the old `read_span(label, 0, 0)` produced — not a clamped, misleading position.

## Impact

CodSpeed (instruction counts, the CI perf gate) reports **+71% render improvement**:

| Benchmark | change |
|-----------|-------:|
| `render[cal.com.ts]` (1.4 MB) | **4.1 ms → 2.4 ms** |
| `render[kitchen-sink.tsx]` (716 KB) | **2.1 ms → 1.3 ms** |
| `render_monochrome[cal.com.ts]` | 4.1 ms → 2.4 ms |
| `render_monochrome[kitchen-sink.tsx]` | 2.1 ms → 1.2 ms |

A local stash/restore wall-time A/B agrees (~46% on the same fixtures). Small-file render and `read_span` itself are unchanged.

## Correctness

A differential test (`line_column_tests::matches_read_span_exhaustively`) checks the derived value against a real `read_span(&(off, 0), 0, 0)` across 100k+ randomized offsets over LF / CRLF / lone-CR and multibyte sources — **full equivalence including the error case** (`None` iff the direct read is `OutOfBounds`), sweeping offsets up to two bytes past EOF. This is the same differential approach used for the earlier `read_span` rewrite, and it caught a CRLF edge case (an offset on the `\n` of a `\r\n`, handled by a normalization step). All 38 graphical snapshot tests (which assert the exact header) stay green.
