### PR TITLE
bench: add a multi-label diagnostic rendering case

### DIFF
--- a/benches/render.rs
+++ b/benches/render.rs
@@ -60,6 +60,27 @@ struct LintDiagnostic {
     span: SourceSpan,
 }
 
+/// A diagnostic with several labels spread across the file — the shape of
+/// oxlint diagnostics that point at a declaration plus related uses. Each
+/// label makes the renderer locate a line/column far into the source.
+#[derive(Debug, Diagnostic, Error)]
+#[error("'resolve' is assigned a value but never used")]
+#[diagnostic(
+    severity = "Warning",
+    code = "eslint(no-unused-vars)",
+    help = "Consider removing this declaration or prefixing it with an underscore"
+)]
+struct MultiLabelDiagnostic {
+    #[source_code]
+    src: NamedSource<String>,
+    #[label("'resolve' is declared here")]
+    decl: SourceSpan,
+    #[label("it is written here")]
+    write: SourceSpan,
+    #[label("but never read after this point")]
+    last: SourceSpan,
+}
+
 /// oxc's interactive default: `GraphicalReportHandler::new()` in a terminal
 /// resolves to unicode characters + RGB colors at a 400 column width.
 fn colored_handler() -> GraphicalReportHandler {
@@ -167,6 +188,41 @@ fn bench(c: &mut Criterion) {
         }
         group.finish();
     }
+
+    // Several labels near each other — a declaration and two related uses in
+    // the same stretch of code, the realistic multi-label shape. The snippet
+    // contexts overlap, so the renderer combines them into one window; every
+    // label read and every merge attempt historically issued its own
+    // `read_span`, i.e. its own scan of the source from byte 0 (five scans
+    // for this shape), so this measures how rendering scales with label count.
+    let mut group = c.benchmark_group("render_multi_label");
+    let handler = colored_handler();
+    for fixture in &fixtures {
+        let start = fixture.span.offset() as usize;
+        // A little under a screen of code apart, scaled down for tiny files
+        // and clamped so every span stays in bounds.
+        let delta = (fixture.source.len() / 20).clamp(1, 250);
+        let near = |n: usize| {
+            let at = (start + n * delta).min(fixture.source.len().saturating_sub(SPAN_LEN));
+            span_at(&fixture.source, at as f64 / fixture.source.len() as f64, SPAN_LEN)
+        };
+        let diagnostic = MultiLabelDiagnostic {
+            src: NamedSource::new(fixture.name, fixture.source.clone()),
+            decl: near(0),
+            write: near(1),
+            last: near(2),
+        };
+        group.bench_function(BenchmarkId::from_parameter(fixture.name), |b| {
+            b.iter(|| {
+                let mut out = String::new();
+                handler
+                    .render_report(&mut out, black_box(&diagnostic as &dyn Diagnostic))
+                    .expect("render succeeds");
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(


### PR DESCRIPTION
Adds a `render_multi_label` benchmark group: a warning with three labels ~250 bytes apart (a declaration and two related uses in the same stretch of code), whose snippet contexts overlap and merge into one window. Each label read and each merge attempt issues its own `read_span` — a scan of the source from byte 0 — so this shape currently pays six full scans per render and measures how rendering scales with label count. On main it lands at 861 µs (kitchen-sink, 716 KB) and 2.05 ms (cal.com, 1.4 MB) locally, versus 288 µs / 671 µs for the single-label `render` group.

The labels are deliberately placed close together: the snippet-merge heuristic combines even far-apart labels into one giant snippet (its `line_count` term counts lines from byte 0), so spread labels would measure rendering thousands of context lines rather than the scans.

Split out of #219 and landing first so CodSpeed records a main baseline for the new cases; #219's comparison then shows its multi-label improvement directly.
