### PR TITLE
perf: scan the source once per snippet render via a shared line-break index

### DIFF
--- a/src/handlers/graphical.rs
+++ b/src/handlers/graphical.rs
@@ -12,7 +12,7 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::{
     Diagnostic, GraphicalTheme, LabeledSpan, MietteSpanContents, ReportHandler, Severity,
-    SourceCode, SourceSpan, SpanContents, ThemeCharacters,
+    SourceCode, SourceSpan, SpanContents, ThemeCharacters, source_impls::SpanScanner,
 };
 
 #[derive(Debug, Clone)]
@@ -478,11 +478,33 @@ impl GraphicalReportHandler {
         }
         labels.sort_unstable_by_key(|l| l.inner().offset());
 
+        // When the source exposes its backing buffer, share one forward scan
+        // across every span lookup below (one per label plus one per merge
+        // attempt); each `read_span` otherwise scans the source from byte 0
+        // again. The scanner bypasses the source's own `read_span`, so
+        // re-attach the source's name the way `NamedSource` would.
+        let mut scanner = source
+            .contiguous_bytes()
+            .map(|bytes| SpanScanner::new(bytes, self.context_lines, self.context_lines));
+        let source_name = source.name();
+        let mut read = |span: &SourceSpan| match scanner.as_mut() {
+            Some(scanner) => scanner.read_span(span).map(|contents| match source_name {
+                Some(name) => MietteSpanContents::new_named(
+                    Cow::Borrowed(name),
+                    contents.data(),
+                    *contents.span(),
+                    contents.line(),
+                    contents.column(),
+                    contents.line_count(),
+                ),
+                None => contents,
+            }),
+            None => source.read_span(span, self.context_lines, self.context_lines),
+        };
+
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
         for right in labels.iter() {
-            let right_conts = source
-                .read_span(right.inner(), self.context_lines, self.context_lines)
-                .map_err(|_| fmt::Error)?;
+            let right_conts = read(right.inner()).map_err(|_| fmt::Error)?;
 
             if contexts.is_empty() {
                 contexts.push((Cow::Borrowed(right), right_conts));
@@ -502,9 +524,7 @@ impl GraphicalReportHandler {
                     new_end - left.offset(),
                 );
                 // Check that the two contexts can be combined
-                if let Ok(new_conts) =
-                    source.read_span(new_span.inner(), self.context_lines, self.context_lines)
-                {
+                if let Ok(new_conts) = read(new_span.inner()) {
                     contexts.pop();
                     contexts.push((Cow::Owned(new_span), new_conts));
                     continue;
@@ -1428,5 +1448,177 @@ impl FancySpan {
 
     fn len(&self) -> usize {
         self.span.len() as usize
+    }
+}
+
+#[cfg(test)]
+mod single_scan_tests {
+    use std::fmt;
+
+    use crate::{
+        Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, MietteError,
+        MietteSpanContents, NamedSource, SourceCode, SourceSpan,
+    };
+
+    /// Deterministic xorshift so any failure reproduces from a fixed seed.
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn below(&mut self, n: usize) -> usize {
+            (self.next() % n as u64) as usize
+        }
+    }
+
+    /// Wraps a `NamedSource` but hides its backing buffer, forcing the
+    /// renderer down the one-`read_span`-per-label path.
+    #[derive(Debug)]
+    struct Opaque(NamedSource<String>);
+
+    impl SourceCode for Opaque {
+        fn read_span<'a>(
+            &'a self,
+            span: &SourceSpan,
+            context_lines_before: usize,
+            context_lines_after: usize,
+        ) -> Result<MietteSpanContents<'a>, MietteError> {
+            self.0.read_span(span, context_lines_before, context_lines_after)
+        }
+
+        fn name(&self) -> Option<&str> {
+            SourceCode::name(&self.0)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestDiag<S> {
+        src: S,
+        labels: Vec<LabeledSpan>,
+    }
+
+    impl<S> fmt::Display for TestDiag<S> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("test diagnostic")
+        }
+    }
+
+    impl<S: fmt::Debug> std::error::Error for TestDiag<S> {}
+
+    impl<S: SourceCode + fmt::Debug> Diagnostic for TestDiag<S> {
+        fn source_code(&self) -> Option<&dyn SourceCode> {
+            Some(&self.src)
+        }
+
+        fn labels(&self) -> Labels {
+            Labels::Many(self.labels.clone())
+        }
+    }
+
+    fn render(diagnostic: &dyn Diagnostic, context_lines: usize) -> (fmt::Result, String) {
+        let handler = GraphicalReportHandler::new_themed(GraphicalTheme::none())
+            .with_context_lines(context_lines);
+        let mut out = String::new();
+        let result = handler.render_report(&mut out, diagnostic);
+        (result, out)
+    }
+
+    /// `render_snippets` has two ways to read spans — a shared
+    /// [`SpanScanner`](crate::source_impls::SpanScanner) scan when the source
+    /// exposes [`SourceCode::contiguous_bytes`], and one `read_span` per
+    /// lookup otherwise. Rendering the same diagnostic through both must
+    /// produce byte-identical reports (or fail identically, for labels past
+    /// the end of the source), across LF / CRLF / lone-CR and multibyte
+    /// sources, 1–4 labels of every overlap shape, and all context sizes.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "renders thousands of graphical diagnostics to differentially fuzz two safe \
+                  code paths — Miri finds no UB here and interpreting the renders is far too slow; \
+                  both paths are exercised under Miri by the normal snapshot tests"
+    )]
+    fn buffer_and_read_span_paths_render_identically() {
+        let alphabets: &[&[&str]] = &[
+            &["a", "\n"],
+            &["a", "b", "c", "\n"],
+            &["a", "b", "\r\n"],
+            &["a", "\r", "\n", "\r\n"],
+            &["x", "y", "\n", "é", "🦀", "\r\n"],
+        ];
+        let mut rng = Rng(0x2545_F491_4F6C_DD1D);
+        let mut checked = 0usize;
+        for alpha in alphabets {
+            for _ in 0..300 {
+                let n = rng.below(24);
+                let mut src = String::new();
+                for _ in 0..n {
+                    src.push_str(alpha[rng.below(alpha.len())]);
+                }
+                // Snap span edges to char boundaries: rendering (unlike
+                // `read_span`) slices the data as UTF-8 text.
+                let floor = |mut byte: usize| {
+                    byte = byte.min(src.len());
+                    while byte > 0 && !src.is_char_boundary(byte) {
+                        byte -= 1;
+                    }
+                    byte
+                };
+                for context_lines in 0..=2 {
+                    let labels: Vec<LabeledSpan> = (0..1 + rng.below(4))
+                        .map(|i| {
+                            // One in six labels lands just past EOF, making
+                            // the whole render fail; both paths must agree on
+                            // that too.
+                            let offset = if rng.below(6) == 0 {
+                                src.len() + 1
+                            } else {
+                                floor(rng.below(src.len() + 1))
+                            };
+                            let mut len =
+                                floor(offset + [0, 1, 2, 6][rng.below(4)]).saturating_sub(offset);
+                            // A zero-length span at offset 0 with zero
+                            // context makes `read_span` return the window
+                            // `[0, 1)` (a pre-existing quirk of its
+                            // saturating span-end arithmetic), which need not
+                            // be valid UTF-8 — rendering panics on both paths
+                            // alike. Widen such spans to the first char.
+                            if context_lines == 0 && offset == 0 && len == 0 {
+                                len = src.chars().next().map_or(0, char::len_utf8);
+                            }
+                            let label = Some(format!("label {i}"));
+                            let span = (offset as u32, len as u32);
+                            if rng.below(4) == 0 {
+                                LabeledSpan::new_primary_with_span(label, span)
+                            } else {
+                                LabeledSpan::new_with_span(label, span)
+                            }
+                        })
+                        .collect();
+
+                    let with_buffer = TestDiag {
+                        src: NamedSource::new("fuzz.rs", src.clone()),
+                        labels: labels.clone(),
+                    };
+                    let without_buffer = TestDiag {
+                        src: Opaque(NamedSource::new("fuzz.rs", src.clone())),
+                        labels: labels.clone(),
+                    };
+                    let (buffer_result, buffer_out) = render(&with_buffer, context_lines);
+                    let (read_span_result, read_span_out) = render(&without_buffer, context_lines);
+                    assert_eq!(
+                        (buffer_result, &buffer_out),
+                        (read_span_result, &read_span_out),
+                        "diverged for src={src:?} context_lines={context_lines} labels={labels:?}"
+                    );
+                    checked += 1;
+                }
+            }
+        }
+        assert!(checked >= 4000, "expected a broad sweep, only checked {checked}");
     }
 }

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -77,4 +77,8 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
     fn name(&self) -> Option<&str> {
         Some(&self.name)
     }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        self.inner().contiguous_bytes()
+    }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -372,6 +372,26 @@ pub trait SourceCode: Send + Sync {
     fn name(&self) -> Option<&str> {
         None
     }
+
+    /// Returns the entire source as one contiguous byte buffer, if it is
+    /// backed by one.
+    ///
+    /// This is an optional fast path: renderers use it to locate several spans
+    /// in a single scan of the source instead of issuing one [`read_span`]
+    /// (a scan from byte 0) per span. Implementations that return `Some` must
+    /// return the same bytes [`read_span`] reads — same content, same offsets
+    /// — and report the source's name via [`name`], since renderers taking
+    /// this path derive span contents from the buffer without calling
+    /// [`read_span`].
+    ///
+    /// The default returns `None`, which keeps every read going through
+    /// [`read_span`].
+    ///
+    /// [`read_span`]: SourceCode::read_span
+    /// [`name`]: SourceCode::name
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        None
+    }
 }
 
 /// A labeled [`SourceSpan`].

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -184,6 +184,332 @@ impl MietteSpanContents<'_> {
     }
 }
 
+/// A line-break index over a contiguous source buffer, built with a single
+/// forward `memchr` scan and able to answer repeated [`read_span`]-shaped
+/// queries without re-reading the source.
+///
+/// [`GraphicalReportHandler`] needs one span lookup per label plus one per
+/// attempted snippet merge, and every [`context_info`] call scans the source
+/// from byte 0 again — a diagnostic with several labels pays for the same
+/// prefix repeatedly. A `SpanScanner` instead scans each source byte at most
+/// once: the first query skips the prefix in bulk exactly like
+/// [`context_info`] does, every line start from the first context window on
+/// is recorded as the scan advances, and each query's result is computed from
+/// that index. Results are identical to what [`context_info`] returns for the
+/// same query — including its quirks, since [`GraphicalReportHandler`] mixes
+/// scanner-served contents with `read_span`-served ones — and the
+/// `scanner_matches_context_info_exhaustively` test enforces the equivalence.
+/// Queries the index cannot serve (an offset before the first indexed line,
+/// which the renderer's sorted label order never produces) fall back to
+/// [`context_info`].
+///
+/// [`read_span`]: crate::SourceCode::read_span
+/// [`GraphicalReportHandler`]: crate::handlers::GraphicalReportHandler
+#[cfg(feature = "fancy-base")]
+pub(crate) struct SpanScanner<'a> {
+    input: &'a [u8],
+    context_lines_before: usize,
+    context_lines_after: usize,
+    /// Starts (byte offsets) of consecutive lines, the first of which is line
+    /// number `base_line`; covers every line whose start lies in
+    /// `[line_starts[0], frontier]`. Empty until the first query seeds it.
+    line_starts: Vec<usize>,
+    /// 0-indexed line number of `line_starts[0]`.
+    base_line: usize,
+    /// Bytes in `[0, frontier)` have been scanned: every line break there is
+    /// either recorded in `line_starts` or (before `line_starts[0]`) summed
+    /// into `base_line`. Never splits a `\r\n` pair.
+    frontier: usize,
+}
+
+#[cfg(feature = "fancy-base")]
+impl<'a> SpanScanner<'a> {
+    pub(crate) fn new(
+        input: &'a [u8],
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Self {
+        Self {
+            input,
+            context_lines_before,
+            context_lines_after,
+            line_starts: Vec::new(),
+            base_line: 0,
+            frontier: 0,
+        }
+    }
+
+    /// Equivalent to `context_info(input, span, context_lines_before,
+    /// context_lines_after)`, but scanning only source bytes no earlier query
+    /// has scanned.
+    pub(crate) fn read_span(
+        &mut self,
+        span: &SourceSpan,
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
+        let span_offset = span.offset() as usize;
+        // The same bulk/detail boundary as `context_info`, adjusted the same
+        // way so a CRLF pair is never split.
+        let mut cut = span_offset.saturating_sub(1).min(self.input.len());
+        if cut > 0 && self.input[cut - 1] == b'\r' {
+            cut -= 1;
+        }
+        let before = self.context_lines_before;
+        if self.line_starts.is_empty() {
+            self.init(cut);
+        } else {
+            if cut < self.line_starts[0] {
+                return context_info(self.input, span, before, self.context_lines_after);
+            }
+            self.cover(cut);
+            // The query's leading context must not reach lines above the
+            // index origin (only possible for spans out of sorted order).
+            let cut_line = self.line_index_of(cut);
+            if cut_line - before.min(cut_line) < self.base_line {
+                return context_info(self.input, span, before, self.context_lines_after);
+            }
+        }
+        self.replay(span, cut)
+    }
+
+    /// First query: scan `[0, cut)` in bulk exactly like [`context_info`],
+    /// keeping the running line number and the last `context_lines_before`
+    /// line starts, then seed the index with those retained starts — the
+    /// first context window's lines.
+    fn init(&mut self, cut: usize) {
+        let before = self.context_lines_before;
+        let mut line_count = 0usize;
+        let mut start_line = 0usize;
+        let mut ring = VecDeque::with_capacity(before + 2);
+        let mut current_line_start = 0usize;
+        for pos in memchr::memchr2_iter(b'\r', b'\n', &self.input[..cut]) {
+            // Skip the `\n` of a CRLF pair already counted at its `\r`.
+            if self.input[pos] == b'\n' && pos > 0 && self.input[pos - 1] == b'\r' {
+                continue;
+            }
+            // A CRLF pair counts as a single line break, ending at the `\n`.
+            let line_end =
+                if self.input[pos] == b'\r' && pos + 1 < cut && self.input[pos + 1] == b'\n' {
+                    pos + 1
+                } else {
+                    pos
+                };
+            line_count += 1;
+            ring.push_back(current_line_start);
+            if ring.len() > before {
+                start_line += 1;
+                ring.pop_front();
+            }
+            current_line_start = line_end + 1;
+        }
+        debug_assert_eq!(start_line + ring.len(), line_count);
+        self.base_line = start_line;
+        self.line_starts.reserve(ring.len() + 8);
+        self.line_starts.extend(ring);
+        self.line_starts.push(current_line_start);
+        self.frontier = cut;
+    }
+
+    /// Extend the index so every break in `[0, target)` is recorded, with one
+    /// bulk `memchr` pass. (A `read_span`-shaped `target` never splits a
+    /// `\r\n` pair, but hold the pair back a byte if one would be.)
+    fn cover(&mut self, mut target: usize) {
+        if target > self.frontier
+            && self.input[target - 1] == b'\r'
+            && self.input.get(target) == Some(&b'\n')
+        {
+            target -= 1;
+        }
+        if target <= self.frontier {
+            return;
+        }
+        for rel in memchr::memchr2_iter(b'\r', b'\n', &self.input[self.frontier..target]) {
+            let pos = self.frontier + rel;
+            if self.input[pos] == b'\n' && pos > 0 && self.input[pos - 1] == b'\r' {
+                continue;
+            }
+            let line_end = if self.input[pos] == b'\r' && self.input.get(pos + 1) == Some(&b'\n') {
+                pos + 1
+            } else {
+                pos
+            };
+            self.line_starts.push(line_end + 1);
+        }
+        self.frontier = target;
+    }
+
+    /// Scan forward from `frontier` to the next line break, recording the
+    /// line start after it. `None` at end of input (with `frontier` advanced
+    /// there so the probe isn't repeated). Returns the terminator as
+    /// `(start, end)` byte positions — equal except for `\r\n`.
+    fn extend(&mut self) -> Option<(usize, usize)> {
+        match memchr::memchr2(b'\r', b'\n', &self.input[self.frontier..]) {
+            Some(rel) => {
+                let pos = self.frontier + rel;
+                let end = if self.input[pos] == b'\r' && self.input.get(pos + 1) == Some(&b'\n') {
+                    pos + 1
+                } else {
+                    pos
+                };
+                self.line_starts.push(end + 1);
+                self.frontier = end + 1;
+                Some((pos, end))
+            }
+            None => {
+                self.frontier = self.input.len();
+                None
+            }
+        }
+    }
+
+    /// 0-indexed line number of the line containing `offset`. Requires
+    /// `line_starts[0] <= offset` and `offset <= frontier`.
+    fn line_index_of(&self, offset: usize) -> usize {
+        self.base_line + self.line_starts.partition_point(|&start| start <= offset) - 1
+    }
+
+    /// Byte offset where line number `line` starts. Requires the line to be
+    /// indexed.
+    fn line_start_of(&self, line: usize) -> usize {
+        self.line_starts[line - self.base_line]
+    }
+
+    /// The break terminating line number `line` (which contains `pos`), as
+    /// `(terminator_start, terminator_end)`, extending the scan on demand.
+    /// `None` when the line runs to end of input.
+    fn break_ending_line(&mut self, line: usize, pos: usize) -> Option<(usize, usize)> {
+        if let Some(&next_start) = self.line_starts.get(line + 1 - self.base_line) {
+            let end = next_start - 1;
+            let start = if end > 0 && self.input[end] == b'\n' && self.input[end - 1] == b'\r' {
+                end - 1
+            } else {
+                end
+            };
+            debug_assert!(start >= pos);
+            return Some((start, end));
+        }
+        // `pos` is on the last indexed line; its terminator (if any) is at or
+        // past the frontier.
+        debug_assert!(pos <= self.frontier);
+        self.extend()
+    }
+
+    /// Compute `context_info`'s exact result for `span` from the index,
+    /// jumping break to break instead of walking byte by byte. Mirrors that
+    /// function's branches one for one — including its quirks: `line_count`
+    /// counts breaks from byte 0 up to where the scan stops, a zero-length
+    /// span enters its post-span phase one byte early, and a `context_lines_before`
+    /// of 0 reports a column that later breaks may have reset — so the two
+    /// stay interchangeable.
+    fn replay(
+        &mut self,
+        span: &SourceSpan,
+        cut: usize,
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
+        let input = self.input;
+        let before = self.context_lines_before;
+        let after = self.context_lines_after;
+        let span_offset = span.offset() as usize;
+        let span_len = span.len() as usize;
+        // `context_info` compares against both of these; they differ for
+        // zero-length spans.
+        let post_threshold = (span_offset + span_len).saturating_sub(1);
+        let break_threshold = span_offset + span_len.saturating_sub(1);
+
+        // State at `cut`, reconstructed from the index instead of a scan.
+        let cut_line = self.line_index_of(cut);
+        let mut line_count = cut_line;
+        // `context_info`'s `before_lines_starts` ring holds the starts of the
+        // last `min(before, lines so far)` lines — always consecutive lines —
+        // so it is tracked as (first line, length) against the index, and
+        // `ring_line` doubles as its `start_line` counter.
+        let mut ring_line = cut_line - before.min(cut_line);
+        let mut ring_len = cut_line - ring_line;
+        let mut start_column = cut - self.line_start_of(cut_line);
+        let mut end_lines = 0usize;
+        let mut post_span = false;
+        let mut post_span_got_newline = false;
+
+        let mut pos = cut;
+        // Exclusive end of the context window (`context_info`'s final
+        // `offset`).
+        let window_end = loop {
+            let brk = self.break_ending_line(line_count, pos);
+            let run_end = brk.map_or(input.len(), |(start, _)| start);
+            // The break-free run `[pos, run_end)`. All `context_info` does
+            // per byte here is advance the column while before the span, and
+            // check whether the post-span phase begins — stopping just past
+            // the first such byte once no more trailing context is wanted.
+            if pos < span_offset {
+                start_column += span_offset.min(run_end) - pos;
+            }
+            if run_end > post_threshold && run_end > pos {
+                post_span = true;
+                if end_lines >= after {
+                    break post_threshold.max(pos) + 1;
+                }
+            }
+            let Some((_, end)) = brk else {
+                // No more breaks: the scan runs off the end of the input.
+                break input.len();
+            };
+            // The break itself.
+            line_count += 1;
+            if end < span_offset {
+                // Before the span: the terminated line becomes (potential)
+                // leading context.
+                start_column = 0;
+                ring_len += 1;
+                if ring_len > before {
+                    ring_line += 1;
+                    ring_len -= 1;
+                }
+            } else if end >= break_threshold && post_span {
+                // Past the span: collect trailing context lines.
+                start_column = 0;
+                if post_span_got_newline {
+                    end_lines += 1;
+                } else {
+                    post_span_got_newline = true;
+                }
+                if end_lines >= after {
+                    break end + 1;
+                }
+            }
+            if end >= post_threshold {
+                post_span = true;
+                if end_lines >= after {
+                    break end + 1;
+                }
+            }
+            pos = end + 1;
+        };
+
+        if window_end >= post_threshold {
+            let starting_offset = if ring_len > 0 {
+                self.line_start_of(ring_line)
+            } else if before == 0 {
+                span_offset
+            } else {
+                0
+            };
+            // A zero-length span starting just past the end of the input
+            // passes the check above but has no content to slice.
+            if starting_offset > window_end {
+                return Err(MietteError::OutOfBounds);
+            }
+            Ok(MietteSpanContents::new(
+                &input[starting_offset..window_end],
+                (starting_offset as u32, (window_end - starting_offset) as u32).into(),
+                ring_line,
+                if before == 0 { start_column } else { 0 },
+                line_count,
+            ))
+        } else {
+            Err(MietteError::OutOfBounds)
+        }
+    }
+}
+
 impl SourceCode for [u8] {
     fn read_span<'a>(
         &'a self,
@@ -193,6 +519,10 @@ impl SourceCode for [u8] {
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         let contents = context_info(self, span, context_lines_before, context_lines_after)?;
         Ok(contents)
+    }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self)
     }
 }
 
@@ -205,6 +535,10 @@ impl SourceCode for &[u8] {
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self)
+    }
 }
 
 impl SourceCode for Vec<u8> {
@@ -215,6 +549,10 @@ impl SourceCode for Vec<u8> {
         context_lines_after: usize,
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         <[u8] as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
+    }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self)
     }
 }
 
@@ -232,6 +570,10 @@ impl SourceCode for str {
             context_lines_after,
         )
     }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self.as_bytes())
+    }
 }
 
 /// Makes `src: &'static str` or `struct S<'a> { src: &'a str }` usable.
@@ -244,6 +586,10 @@ impl SourceCode for &str {
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
     }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self.as_bytes())
+    }
 }
 
 impl SourceCode for String {
@@ -254,6 +600,10 @@ impl SourceCode for String {
         context_lines_after: usize,
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         <str as SourceCode>::read_span(self, span, context_lines_before, context_lines_after)
+    }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self.as_bytes())
     }
 }
 
@@ -269,6 +619,10 @@ impl<T: ?Sized + SourceCode> SourceCode for Arc<T> {
 
     fn name(&self) -> Option<&str> {
         self.as_ref().name()
+    }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        self.as_ref().contiguous_bytes()
     }
 }
 
@@ -292,6 +646,10 @@ where
 
     fn name(&self) -> Option<&str> {
         self.as_ref().name()
+    }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        self.as_ref().contiguous_bytes()
     }
 }
 
@@ -486,5 +844,137 @@ mod line_column_tests {
             }
         }
         assert!(checked > 100_000, "expected a broad sweep, only checked {checked}");
+    }
+}
+
+#[cfg(all(test, feature = "fancy-base"))]
+mod scanner_tests {
+    use super::*;
+
+    /// Deterministic xorshift so any failure reproduces from a fixed seed.
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+        fn below(&mut self, n: usize) -> usize {
+            (self.next() % n as u64) as usize
+        }
+    }
+
+    /// Run one query against a (stateful) scanner and assert the result is
+    /// identical to a fresh `context_info` — data, span, line, column, and
+    /// `line_count` on success, `OutOfBounds` on failure. `history` is the
+    /// queries already issued to this scanner, which its state (and therefore
+    /// any failure) depends on.
+    fn check(
+        scanner: &mut SpanScanner<'_>,
+        input: &[u8],
+        span: (usize, usize),
+        before: usize,
+        after: usize,
+        history: &[(usize, usize)],
+    ) {
+        let source_span: SourceSpan = (span.0 as u32, span.1 as u32).into();
+        let expected = context_info(input, &source_span, before, after);
+        let got = scanner.read_span(&source_span);
+        let src = String::from_utf8_lossy(input);
+        match (&expected, &got) {
+            (Ok(expected), Ok(got)) => {
+                let fields =
+                    |c: &MietteSpanContents<'_>| (*c.span(), c.line(), c.column(), c.line_count());
+                assert_eq!(
+                    (fields(expected), expected.data()),
+                    (fields(got), got.data()),
+                    "mismatch for src={src:?} span={span:?} before={before} after={after} \
+                     history={history:?}"
+                );
+            }
+            (Err(MietteError::OutOfBounds), Err(MietteError::OutOfBounds)) => {}
+            _ => panic!(
+                "expected {expected:?}, got {got:?} for src={src:?} span={span:?} \
+                 before={before} after={after} history={history:?}"
+            ),
+        }
+    }
+
+    /// Differentially fuzz `SpanScanner` against `context_info` with query
+    /// *sequences* — the scanner's whole point is state carried between
+    /// queries, so single-shot checks would miss its interesting bugs. Covers
+    /// LF / CRLF / lone-CR and multibyte sources; spans of any alignment
+    /// (byte offsets, not char boundaries — neither function cares) including
+    /// past-EOF ones; queries in random order (which exercises the
+    /// out-of-index fallbacks) and in the renderer's sorted-then-merge order.
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "equivalence fuzzer over safe, bounds-checked code — Miri finds no UB here \
+                  and interprets it orders of magnitude slower; the scanner path is still \
+                  exercised under Miri by the normal snapshot tests"
+    )]
+    fn scanner_matches_context_info_exhaustively() {
+        let alphabets: &[&[&str]] = &[
+            &["a", "\n"],
+            &["a", "b", "c", "\n"],
+            &["a", "b", "\r\n"],
+            &["a", "\r", "\n", "\r\n"],
+            &["x", "y", "\n", "é", "🦀", "\r\n"],
+        ];
+        let mut rng = Rng(0xA076_1D64_78BD_642F);
+        let mut checked = 0usize;
+        for alpha in alphabets {
+            for _ in 0..700 {
+                let n = rng.below(16);
+                let mut s = String::new();
+                for _ in 0..n {
+                    s.push_str(alpha[rng.below(alpha.len())]);
+                }
+                let input = s.as_bytes();
+                for (before, after) in [(0, 0), (1, 1), (2, 2), (0, 2), (2, 0)] {
+                    let mut spans: Vec<(usize, usize)> = (0..6)
+                        .map(|_| (rng.below(input.len() + 3), [0, 1, 2, 5][rng.below(4)]))
+                        .collect();
+
+                    // Random order: queries may jump backwards past the
+                    // index origin.
+                    let mut scanner = SpanScanner::new(input, before, after);
+                    for i in 0..spans.len() {
+                        check(&mut scanner, input, spans[i], before, after, &spans[..i]);
+                        checked += 1;
+                    }
+
+                    // The renderer's order: labels sorted by offset, then a
+                    // merge attempt spanning from the first label to the
+                    // furthest end.
+                    spans.sort_unstable();
+                    let first = spans[0].0;
+                    let merged_end = spans.iter().map(|&(o, l)| o + l).max().unwrap();
+                    spans.push((first, merged_end - first));
+                    let mut scanner = SpanScanner::new(input, before, after);
+                    for i in 0..spans.len() {
+                        check(&mut scanner, input, spans[i], before, after, &spans[..i]);
+                        checked += 1;
+                    }
+                }
+            }
+        }
+        assert!(checked > 100_000, "expected a broad sweep, only checked {checked}");
+    }
+
+    /// The empty-source and just-past-EOF edge cases `context_info` special
+    /// cases, issued through one scanner.
+    #[test]
+    fn zero_length_spans_at_eof() {
+        let mut scanner = SpanScanner::new(b"", 0, 0);
+        check(&mut scanner, b"", (0, 0), 0, 0, &[]);
+        check(&mut scanner, b"", (1, 0), 0, 0, &[(0, 0)]);
+        let mut scanner = SpanScanner::new(b"a", 1, 1);
+        check(&mut scanner, b"a", (1, 0), 1, 1, &[]);
+        check(&mut scanner, b"a", (2, 0), 1, 1, &[(1, 0)]);
     }
 }


### PR DESCRIPTION
GraphicalReportHandler::render_snippets issued one read_span per label plus
one per attempted context merge, and each call scans the source from byte 0 —
a three-label diagnostic pays for five full scans. Introduce
SourceCode::contiguous_bytes() (defaulted to None) so byte-backed sources can
expose their buffer, and a SpanScanner that walks it once with memchr,
indexing line starts from the first context window onward and answering every
subsequent lookup from the index with results bit-identical to read_span's.
Sources without a contiguous buffer keep the per-label read_span path.

Equivalence is enforced by a 100k-case differential fuzz of query sequences
against context_info, and by rendering randomized multi-label diagnostics
through both paths and asserting byte-identical output.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>