### PR TITLE
refactor: remove dead commented-out code from the graphical renderer

### DIFF
--- a/src/handlers/graphical/handler.rs
+++ b/src/handlers/graphical/handler.rs
@@ -43,7 +43,6 @@ pub struct GraphicalReportHandler {
     pub(crate) break_words: bool,
     pub(crate) word_separator: Option<textwrap::WordSeparator>,
     pub(crate) word_splitter: Option<textwrap::WordSplitter>,
-    // pub(crate) highlighter: MietteHighlighter,
     pub(crate) link_display_text: Option<String>,
 }
 
@@ -71,7 +70,6 @@ impl GraphicalReportHandler {
             break_words: true,
             word_separator: None,
             word_splitter: None,
-            // highlighter: MietteHighlighter::default(),
             link_display_text: None,
         }
     }
@@ -90,7 +88,6 @@ impl GraphicalReportHandler {
             break_words: true,
             word_separator: None,
             word_splitter: None,
-            // highlighter: MietteHighlighter::default(),
             link_display_text: None,
         }
     }
@@ -181,23 +178,6 @@ impl GraphicalReportHandler {
         self.context_lines = lines;
         self
     }
-
-    // /// Enable syntax highlighting for source code snippets, using the given
-    // /// [`Highlighter`]. See the [crate::highlighters] crate for more details.
-    // pub fn with_syntax_highlighting(
-    // mut self,
-    // highlighter: impl Highlighter + Send + Sync + 'static,
-    // ) -> Self {
-    // self.highlighter = MietteHighlighter::from(highlighter);
-    // self
-    // }
-
-    // /// Disable syntax highlighting. This uses the
-    // /// [`crate::highlighters::BlankHighlighter`] as a no-op highlighter.
-    // pub fn without_syntax_highlighting(mut self) -> Self {
-    // self.highlighter = MietteHighlighter::nocolor();
-    // self
-    // }
 
     /// Sets the display text for links.
     /// Miette displays `(link)` if this option is not set.

--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -25,7 +25,6 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
     ) -> fmt::Result {
-        // self.render_header(f, diagnostic)?;
         writeln!(f)?;
         self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();
@@ -110,64 +109,6 @@ impl GraphicalReportHandler {
         };
         let title = textwrap::fill(&title, opts);
         writeln!(f, "{title}")?;
-
-        // if !self.with_cause_chain {
-        // return Ok(());
-        // }
-
-        // if let Some(mut cause_iter) = diagnostic
-        // .diagnostic_source()
-        // .map(DiagnosticChain::from_diagnostic)
-        // .or_else(|| diagnostic.source().map(DiagnosticChain::from_stderror))
-        // .map(|it| it.peekable())
-        // {
-        // while let Some(error) = cause_iter.next() {
-        // let is_last = cause_iter.peek().is_none();
-        // let char = if !is_last {
-        // self.theme.characters.lcross
-        // } else {
-        // self.theme.characters.lbot
-        // };
-        // let initial_indent = format!(
-        // "  {}{}{} ",
-        // char, self.theme.characters.hbar, self.theme.characters.rarrow
-        // )
-        // .style(severity_style)
-        // .to_string();
-        // let rest_indent =
-        // format!("  {}   ", if is_last { ' ' } else { self.theme.characters.vbar })
-        // .style(severity_style)
-        // .to_string();
-        // let mut opts = textwrap::Options::new(width)
-        // .initial_indent(&initial_indent)
-        // .subsequent_indent(&rest_indent)
-        // .break_words(self.break_words);
-        // if let Some(word_separator) = self.word_separator {
-        // opts = opts.word_separator(word_separator);
-        // }
-        // if let Some(word_splitter) = self.word_splitter.clone() {
-        // opts = opts.word_splitter(word_splitter);
-        // }
-
-        // match error {
-        // ErrorKind::Diagnostic(diag) => {
-        // let mut inner = String::new();
-
-        // let mut inner_renderer = self.clone();
-        // // Don't print footer for inner errors
-        // inner_renderer.footer = None;
-        // // Cause chains are already flattened, so don't double-print the nested error
-        // inner_renderer.with_cause_chain = false;
-        // inner_renderer.render_report(&mut inner, diag)?;
-
-        // writeln!(f, "{}", self.wrap(&inner, opts))?;
-        // }
-        // ErrorKind::StdError(err) => {
-        // writeln!(f, "{}", self.wrap(&err.to_string(), opts))?;
-        // }
-        // }
-        // }
-        // }
 
         Ok(())
     }

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -125,8 +125,6 @@ impl GraphicalReportHandler {
             .map(|(label, st)| FancySpan::new(label.label(), *label.inner(), st))
             .collect::<Vec<_>>();
 
-        // let mut highlighter_state = self.highlighter.start_highlighter_state(&*contents);
-
         // The max number of gutter-lines that will be active at any given
         // point. We need this to figure out indentation, so we do one loop
         // over the lines to see what the damage is gonna be.
@@ -198,10 +196,7 @@ impl GraphicalReportHandler {
             self.render_line_gutter(f, max_gutter, line, &labels)?;
 
             // And _now_ we can print out the line text itself!
-            // let styled_text =
-            // StyledList::from(highlighter_state.highlight_line(&line.text)).to_string();
-            let styled_text = &line.text;
-            self.render_line_text(f, styled_text)?;
+            self.render_line_text(f, line.text)?;
 
             // Next, we write all the highlights that apply to this particular line.
             let (single_line, multi_line): (Vec<_>, Vec<_>) = labels


### PR DESCRIPTION
Drop the commented-out remnants of two upstream miette features that are
disabled in this fork:

- Syntax highlighting: the `highlighter` field, the `with_syntax_highlighting`
  / `without_syntax_highlighting` builder stubs, and the per-line highlighter
  calls in `render_context`. No live code referenced any of them.
- Cause-chain rendering: the large commented block in `render_causes` and the
  commented `render_header` call in `render_report`.

The `with_cause_chain`/`without_cause_chain` builders stay — `MietteHandlerOpts`
in src/handler.rs still calls them, even though the graphical renderer currently
ignores the flag. Rendering output is unchanged.
