### PR TITLE
docs: document the flattened error-report modules

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1,3 +1,7 @@
+//! `Display` / `Debug` for `ErrorImpl`, routed through the installed
+//! [`ReportHandler`](crate::ReportHandler) (or the value's own formatting when
+//! there is no handler).
+
 use core::fmt;
 
 use crate::{ptr::Ref, report_impl::ErrorImpl};

--- a/src/into_diagnostic.rs
+++ b/src/into_diagnostic.rs
@@ -1,3 +1,6 @@
+//! The [`IntoDiagnostic`] extension trait: `.into_diagnostic()` turns any
+//! [`std::error::Error`] into a [`Report`](crate::Report).
+
 use thiserror::Error;
 
 use crate::{Diagnostic, Report};

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -4,6 +4,11 @@
     clippy::new_ret_no_self,
     clippy::wrong_self_convention
 )]
+//! Autoref-specialization dispatch for `miette!(expr)`: picks up the argument's
+//! [`std::error::Error`] impl when it has one, otherwise falls back to
+//! `Display + Debug`. Vendored from [eyre](https://docs.rs/eyre) / anyhow; the
+//! comment below explains the mechanism in detail.
+
 // Tagged dispatch mechanism for resolving the behavior of `miette!($expr)`.
 //
 // When miette! is given a single expr argument to turn into miette::Report, we

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::needless_doctest_main)]
+//! The `bail!`, `ensure!`, and `miette!` macros for building and returning
+//! [`Report`](crate::Report)s. Vendored from [eyre](https://docs.rs/eyre) / anyhow.
 
 /// Return early with an error.
 ///

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -1,3 +1,7 @@
+//! Thin owning/borrowing pointer wrappers (`Own`, `Ref`, `Mut`) that
+//! [`Report`](crate::Report)'s type-erased storage is built on. Vendored from
+//! [anyhow](https://docs.rs/anyhow)'s `ptr.rs`.
+
 use std::{marker::PhantomData, ptr::NonNull};
 
 #[repr(transparent)]

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,4 +1,14 @@
 #![allow(clippy::needless_doctest_main, clippy::new_ret_no_self, clippy::wrong_self_convention)]
+//! [`Report`] — miette's boxed, type-erased diagnostic — plus the
+//! [`ReportHandler`] rendering hook, [`set_hook`], and the [`Result`] alias.
+//!
+//! `Report` is one machine word: a thin pointer to a heap `ErrorImpl` whose
+//! pointer/vtable machinery lives in `report_impl` and `ptr`. This module and
+//! its siblings (`report_impl`, `ptr`, `kind`, `macros`, `wrap_err`,
+//! `into_diagnostic`, `fmt`) are a vendored fork of [eyre](https://docs.rs/eyre)
+//! / [anyhow](https://docs.rs/anyhow), adapted to carry a miette
+//! [`Diagnostic`](crate::Diagnostic).
+
 use std::{error::Error as StdError, sync::OnceLock};
 
 #[doc(hidden)]

--- a/src/report_impl.rs
+++ b/src/report_impl.rs
@@ -1,3 +1,13 @@
+//! The guts of [`Report`](crate::Report): `ErrorImpl` and the hand-built
+//! `ErrorVTable` that let `Report` be a single-word pointer instead of a
+//! `Box<dyn Error>` fat pointer.
+//!
+//! Vendored from [eyre](https://docs.rs/eyre) / [anyhow](https://docs.rs/anyhow).
+//! An `ErrorImpl<E>` sits behind a thin pointer next to a vtable of function
+//! pointers (`object_drop`, `object_ref`, `object_downcast`, …) that stand in
+//! for the erased type `E`. The `unsafe` upholds subtle layout and
+//! type-erasure invariants — prefer re-syncing from upstream over editing it.
+
 use core::{
     any::TypeId,
     fmt::{self, Debug, Display},


### PR DESCRIPTION
Give each module dissolved out of `eyreish` a `//!` header explaining its role
and its eyre/anyhow provenance, so opening e.g. `report_impl.rs` (~800 lines of
unsafe vtable) makes clear it is vendored type-erasure machinery to re-sync from
upstream rather than hand-edit. Comments only — no code changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>