### PR TITLE
refactor: remove the inert graphical cause-chain builders

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -239,13 +239,6 @@ impl MietteHandlerOpts {
             let theme = self.theme.unwrap_or(GraphicalTheme { characters, styles });
             let mut handler =
                 GraphicalReportHandler::new_themed(theme).with_width(width).with_links(linkify);
-            if let Some(with_cause_chain) = self.with_cause_chain {
-                if with_cause_chain {
-                    handler = handler.with_cause_chain();
-                } else {
-                    handler = handler.without_cause_chain();
-                }
-            }
             if let Some(footer) = self.footer {
                 handler = handler.with_footer(footer);
             }

--- a/src/handlers/graphical/handler.rs
+++ b/src/handlers/graphical/handler.rs
@@ -29,8 +29,6 @@ pub struct GraphicalReportHandler {
     ///
     /// Default: `4`
     pub(crate) tab_width: usize,
-    /// Unused.
-    pub(crate) with_cause_chain: bool,
     /// Whether to wrap lines to fit the width.
     ///
     /// Default: `true`
@@ -65,7 +63,6 @@ impl GraphicalReportHandler {
             footer: None,
             context_lines: 1,
             tab_width: 4,
-            with_cause_chain: false,
             wrap_lines: true,
             break_words: true,
             word_separator: None,
@@ -84,7 +81,6 @@ impl GraphicalReportHandler {
             context_lines: 1,
             tab_width: 4,
             wrap_lines: true,
-            with_cause_chain: true,
             break_words: true,
             word_separator: None,
             word_splitter: None,
@@ -101,20 +97,6 @@ impl GraphicalReportHandler {
     /// Whether to enable error code linkification using [`Diagnostic::url()`](crate::Diagnostic::url).
     pub fn with_links(mut self, links: bool) -> Self {
         self.links = if links { LinkStyle::Link } else { LinkStyle::Text };
-        self
-    }
-
-    /// Include the cause chain of the top-level error in the graphical output,
-    /// if available.
-    pub fn with_cause_chain(mut self) -> Self {
-        self.with_cause_chain = true;
-        self
-    }
-
-    /// Do not include the cause chain of the top-level error in the graphical
-    /// output.
-    pub fn without_cause_chain(mut self) -> Self {
-        self.with_cause_chain = false;
         self
     }
 

--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -139,9 +139,7 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         let related = diagnostic.related();
         if !related.is_empty() {
-            let mut inner_renderer = self.clone();
-            // Re-enable the printing of nested cause chains for related errors
-            inner_renderer.with_cause_chain = true;
+            let inner_renderer = self.clone();
             writeln!(f)?;
             for rel in related.iter().copied() {
                 match rel.severity() {


### PR DESCRIPTION
Graphical cause-chain rendering was disabled long ago (the code was commented
out, then deleted in the dead-code sweep), leaving `GraphicalReportHandler`'s
`with_cause_chain` field write-only and its `with_cause_chain()` /
`without_cause_chain()` builders as no-ops that misleadingly imply the graphical
renderer prints `Caused by:` chains — it does not.

Remove the field, the two public builders, the `MietteHandlerOpts` → graphical
wiring, and the no-op assignment in `render_related`. The option is untouched for
the narratable handler, which does honor it: `MietteHandlerOpts::with_cause_chain`
still drives `NarratableReportHandler`.

Rendered output is unchanged — the removed code did nothing. This drops two
public no-op methods from `GraphicalReportHandler`; breaking on paper, but they
had no effect.