### PR TITLE
refactor: remove the unused ErrReport / EyreContext compat aliases

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -11,15 +11,9 @@
 
 use std::{error::Error as StdError, sync::OnceLock};
 
-#[doc(hidden)]
-#[allow(unreachable_pub)]
-pub use Report as ErrReport;
 /// Compatibility re-export of `Report` for interop with `anyhow`
 #[allow(unreachable_pub)]
 pub use Report as Error;
-#[doc(hidden)]
-#[allow(unreachable_pub)]
-pub use ReportHandler as EyreContext;
 
 #[cfg(not(feature = "fancy-base"))]
 use crate::DebugReportHandler;


### PR DESCRIPTION
`ErrReport` and `EyreContext` were `#[doc(hidden)]` eyre-migration aliases
(`Report` and `ReportHandler` under eyre's names). Nothing references them — not
this crate, its tests, or oxc — and migrating *from* eyre isn't relevant to this
fork. Remove both.

The `Error` alias (used by oxc) and the `WrapErr`/`Context` anyhow-compat trait
(a tested, working feature) are kept.
