### PR TITLE
refactor: remove the unused with_urls builder

### DIFF
--- a/src/handlers/graphical/handler.rs
+++ b/src/handlers/graphical/handler.rs
@@ -46,7 +46,6 @@ pub struct GraphicalReportHandler {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LinkStyle {
-    None,
     Link,
     Text,
 }
@@ -97,19 +96,6 @@ impl GraphicalReportHandler {
     /// Whether to enable error code linkification using [`Diagnostic::url()`](crate::Diagnostic::url).
     pub fn with_links(mut self, links: bool) -> Self {
         self.links = if links { LinkStyle::Link } else { LinkStyle::Text };
-        self
-    }
-
-    /// Whether to include [`Diagnostic::url()`](crate::Diagnostic::url) in the output.
-    ///
-    /// Disabling this is not recommended, but can be useful for more easily
-    /// reproducible tests, as `url(docsrs)` links are version-dependent.
-    pub fn with_urls(mut self, urls: bool) -> Self {
-        self.links = match (self.links, urls) {
-            (_, false) => LinkStyle::None,
-            (LinkStyle::None, true) => LinkStyle::Link,
-            (links, true) => links,
-        };
         self
     }
 


### PR DESCRIPTION
`GraphicalReportHandler::with_urls` had zero callers anywhere — the crate, its
tests, or oxc — and it was the only producer of `LinkStyle::None`. Remove the
method and the now-unconstructible `None` variant; the renderer only ever matches
`Link`/`Text` (with a catch-all), so nothing else changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>