### PR TITLE
perf: use byte widths for plain ascii

### DIFF
--- a/src/handlers/graphical/line.rs
+++ b/src/handlers/graphical/line.rs
@@ -185,7 +185,13 @@ impl GraphicalReportHandler {
             }
         }
         let text = &line.text[..text_index.min(line.text.len())];
-        let text_width = self.line_visual_char_width(text).sum();
+        // Plain ASCII is exactly one terminal column per byte.
+        let text_width =
+            if text.is_ascii() && memchr::memchr2(b'\t', b'\x1b', text.as_bytes()).is_none() {
+                text.len()
+            } else {
+                self.line_visual_char_width(text).sum()
+            };
         if text_index > line.text.len() {
             // Spans extending past the end of the line are always rendered as
             // one column past the end of the visible line.


### PR DESCRIPTION
Use byte length for plain ASCII label prefixes, bypassing grapheme iteration while preserving the existing tab, ANSI, and Unicode path. Controlled Criterion A/B improves representative renders by 2.5–11.2%; validated across graphical snapshots, Clippy, WASM, benchmarks, and Rust 1.85.