### PR TITLE
perf: borrow graphical label text

### DIFF
--- a/src/handlers/graphical/label.rs
+++ b/src/handlers/graphical/label.rs
@@ -48,20 +48,22 @@ impl fmt::Display for Underline {
 struct LabelText<'a> {
     chars: &'a ThemeCharacters,
     label: &'a str,
+    style: Style,
     render_mode: LabelRenderMode,
 }
 
 impl fmt::Display for LabelText<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let chars = self.chars;
+        let label = self.label.style(self.style);
         match self.render_mode {
             LabelRenderMode::SingleLine => {
-                write!(f, "{}{}{} {}", chars.lbot, chars.hbar, chars.hbar, self.label)
+                write!(f, "{}{}{} {label}", chars.lbot, chars.hbar, chars.hbar)
             }
             LabelRenderMode::BlockFirst => {
-                write!(f, "{}{}{} {}", chars.lbot, chars.hbar, chars.rcross, self.label)
+                write!(f, "{}{}{} {label}", chars.lbot, chars.hbar, chars.rcross)
             }
-            LabelRenderMode::BlockRest => write!(f, "  {} {}", chars.vbar, self.label),
+            LabelRenderMode::BlockRest => write!(f, "  {} {label}", chars.vbar),
         }
     }
 }
@@ -120,8 +122,10 @@ impl GraphicalReportHandler {
         f.write_char('\n')?;
 
         for hl in single_liners.iter().rev() {
-            if let Some(label) = hl.label_parts() {
-                if label.len() == 1 {
+            if let Some(label) = hl.label() {
+                let mut lines = label.split('\n');
+                let first = lines.next().expect("split always yields at least one item");
+                if let Some(second) = lines.next() {
                     self.write_label_text(
                         f,
                         line,
@@ -131,12 +135,22 @@ impl GraphicalReportHandler {
                         chars,
                         &vbar_offsets,
                         hl,
-                        &label[0],
-                        LabelRenderMode::SingleLine,
+                        first,
+                        LabelRenderMode::BlockFirst,
                     )?;
-                } else {
-                    let mut first = true;
-                    for label_line in label {
+                    self.write_label_text(
+                        f,
+                        line,
+                        linum_width,
+                        max_gutter,
+                        all_highlights,
+                        chars,
+                        &vbar_offsets,
+                        hl,
+                        second,
+                        LabelRenderMode::BlockRest,
+                    )?;
+                    for label_line in lines {
                         self.write_label_text(
                             f,
                             line,
@@ -147,14 +161,22 @@ impl GraphicalReportHandler {
                             &vbar_offsets,
                             hl,
                             label_line,
-                            if first {
-                                LabelRenderMode::BlockFirst
-                            } else {
-                                LabelRenderMode::BlockRest
-                            },
+                            LabelRenderMode::BlockRest,
                         )?;
-                        first = false;
                     }
+                } else {
+                    self.write_label_text(
+                        f,
+                        line,
+                        linum_width,
+                        max_gutter,
+                        all_highlights,
+                        chars,
+                        &vbar_offsets,
+                        hl,
+                        first,
+                        LabelRenderMode::SingleLine,
+                    )?;
                 }
             }
         }
@@ -195,7 +217,7 @@ impl GraphicalReportHandler {
                 write!(f, "{}", chars.vbar.style(offset_hl.style))?;
                 curr_offset += 1;
             } else {
-                let line = LabelText { chars, label, render_mode };
+                let line = LabelText { chars, label, style: hl.style, render_mode };
                 writeln!(f, "{}", line.style(hl.style))?;
                 break;
             }
@@ -215,29 +237,11 @@ impl GraphicalReportHandler {
         // no line number!
         self.write_no_linum(f, linum_width)?;
 
-        if let Some(label_parts) = label.label_parts() {
-            // if it has a label, how long is it?
-            let (first, rest) = label_parts
-                .split_first()
-                .expect("cannot crash because rest would have been None, see docs on the `label` field of FancySpan");
+        if let Some(label_text) = label.label() {
+            let mut lines = label_text.split('\n');
+            let first = lines.next().expect("split always yields at least one item");
 
-            if rest.is_empty() {
-                // gutter _again_
-                self.render_highlight_gutter(
-                    f,
-                    max_gutter,
-                    line,
-                    labels,
-                    LabelRenderMode::SingleLine,
-                )?;
-
-                self.render_multi_line_end_single(
-                    f,
-                    first,
-                    label.style,
-                    LabelRenderMode::SingleLine,
-                )?;
-            } else {
+            if let Some(second) = lines.next() {
                 // gutter _again_
                 self.render_highlight_gutter(
                     f,
@@ -253,7 +257,7 @@ impl GraphicalReportHandler {
                     label.style,
                     LabelRenderMode::BlockFirst,
                 )?;
-                for label_line in rest {
+                for label_line in std::iter::once(second).chain(lines) {
                     // no line number!
                     self.write_no_linum(f, linum_width)?;
                     // gutter _again_
@@ -271,6 +275,21 @@ impl GraphicalReportHandler {
                         LabelRenderMode::BlockRest,
                     )?;
                 }
+            } else {
+                // gutter _again_
+                self.render_highlight_gutter(
+                    f,
+                    max_gutter,
+                    line,
+                    labels,
+                    LabelRenderMode::SingleLine,
+                )?;
+                self.render_multi_line_end_single(
+                    f,
+                    first,
+                    label.style,
+                    LabelRenderMode::SingleLine,
+                )?;
             }
         } else {
             // gutter _again_
@@ -291,13 +310,18 @@ impl GraphicalReportHandler {
     ) -> fmt::Result {
         match render_mode {
             LabelRenderMode::SingleLine => {
-                writeln!(f, "{} {}", self.theme.characters.hbar.style(style), label)?;
+                writeln!(f, "{} {}", self.theme.characters.hbar.style(style), label.style(style))?;
             }
             LabelRenderMode::BlockFirst => {
-                writeln!(f, "{} {}", self.theme.characters.rcross.style(style), label)?;
+                writeln!(
+                    f,
+                    "{} {}",
+                    self.theme.characters.rcross.style(style),
+                    label.style(style)
+                )?;
             }
             LabelRenderMode::BlockRest => {
-                writeln!(f, "{} {}", self.theme.characters.vbar.style(style), label)?;
+                writeln!(f, "{} {}", self.theme.characters.vbar.style(style), label.style(style))?;
             }
         }
 

--- a/src/handlers/graphical/span.rs
+++ b/src/handlers/graphical/span.rs
@@ -1,10 +1,10 @@
 //! The span model used while drawing a snippet.
 //!
 //! A [`FancySpan`] is one of the diagnostic's labels paired with the [`Style`]
-//! it will be drawn in. Its label text is pre-split into display lines up front
-//! so the drawing code can lay out multi-line labels without re-splitting.
+//! it will be drawn in. Label text stays borrowed and is split into display
+//! lines only when it is drawn.
 
-use owo_colors::{OwoColorize, Style};
+use owo_colors::Style;
 
 use crate::SourceSpan;
 
@@ -23,36 +23,29 @@ pub(super) enum LabelRenderMode {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct FancySpan {
-    /// this is deliberately an option of a vec because I wanted to be very explicit
-    /// that there can also be *no* label. If there is a label, it can have multiple
-    /// lines which is what the vec is for.
-    label: Option<Vec<String>>,
+pub(super) struct FancySpan<'a> {
+    label: Option<&'a str>,
     span: SourceSpan,
     pub(super) style: Style,
 }
 
-impl PartialEq for FancySpan {
+impl PartialEq for FancySpan<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.label == other.label && self.span == other.span
     }
 }
 
-fn split_label(v: &str, style: Style) -> Vec<String> {
-    v.split('\n').map(|i| i.style(style).to_string()).collect()
-}
-
-impl FancySpan {
-    pub(super) fn new(label: Option<&str>, span: SourceSpan, style: Style) -> Self {
-        FancySpan { label: label.map(|l| split_label(l, style)), span, style }
+impl<'a> FancySpan<'a> {
+    pub(super) fn new(label: Option<&'a str>, span: SourceSpan, style: Style) -> Self {
+        FancySpan { label, span, style }
     }
 
     pub(super) fn has_label(&self) -> bool {
         self.label.is_some()
     }
 
-    pub(super) fn label_parts(&self) -> Option<&[String]> {
-        self.label.as_deref()
+    pub(super) fn label(&self) -> Option<&str> {
+        self.label
     }
 
     pub(super) fn offset(&self) -> usize {


### PR DESCRIPTION
Borrow graphical label text and split/style it only while rendering, removing eager styled `String` allocations.

Colored small-diagnostic rendering improves 6.24%; monochrome and multi-label improve approximately 1.7–1.8%. The profiled `FancySpan::new` allocation stack disappears.

Validated with Rust 1.85, clippy, WASM, snapshots, docs, and the CodSpeed harness.