### PR TITLE
ci: skip exhaustive textwrap test under miri

### DIFF
--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -319,6 +319,11 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "exhaustive equivalence check over safe text wrapping code; interpreting every \
+                  textwrap case under Miri takes more than 16 minutes"
+    )]
     fn fill_fast_path_matches_textwrap() {
         let texts = [
             "",


### PR DESCRIPTION
Skip the exhaustive safe textwrap equivalence check only under Miri; it continues to run in normal CI.

The check consumed 983 seconds of a 19m26s Miri job. Strict-provenance Miri coverage for the unsafe report internals remains enabled.

Validated with the full normal suite, clippy/MSRV, and the unsafe-focused strict-provenance Miri targets.