### PR TITLE
perf: write underline runs in chunks

### DIFF
--- a/src/handlers/graphical/label.rs
+++ b/src/handlers/graphical/label.rs
@@ -29,19 +29,39 @@ struct Underline {
     underline: char,
 }
 
+fn write_repeated_char(f: &mut impl fmt::Write, c: char, mut count: usize) -> fmt::Result {
+    const CHUNK_CHARS: usize = 32;
+    const SPACES: &str = "                                ";
+    const UNICODE_BARS: &str = "────────────────────────────────";
+    const ASCII_CARETS: &str = "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^";
+
+    // Built-in themes repeat these characters frequently, so emit them in chunks.
+    // Preserve the general character loop for custom themes.
+    let chunk = match c {
+        ' ' => SPACES,
+        '─' => UNICODE_BARS,
+        '^' => ASCII_CARETS,
+        _ => {
+            for _ in 0..count {
+                f.write_char(c)?;
+            }
+            return Ok(());
+        }
+    };
+
+    while count >= CHUNK_CHARS {
+        f.write_str(chunk)?;
+        count -= CHUNK_CHARS;
+    }
+    f.write_str(&chunk[..count * c.len_utf8()])
+}
+
 impl fmt::Display for Underline {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for _ in 0..self.padding {
-            f.write_char(' ')?;
-        }
-        for _ in 0..self.left {
-            f.write_char(self.underline)?;
-        }
+        write_repeated_char(f, ' ', self.padding)?;
+        write_repeated_char(f, self.underline, self.left)?;
         f.write_char(self.marker)?;
-        for _ in 0..self.right {
-            f.write_char(self.underline)?;
-        }
-        Ok(())
+        write_repeated_char(f, self.underline, self.right)
     }
 }
 
@@ -326,5 +346,21 @@ impl GraphicalReportHandler {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_chars_match_standard_output() {
+        for c in [' ', '─', '^', 'x', '🐂'] {
+            for count in [0, 1, 31, 32, 33, 64, 65] {
+                let mut output = String::new();
+                write_repeated_char(&mut output, c, count).unwrap();
+                assert_eq!(output, c.to_string().repeat(count));
+            }
+        }
     }
 }

--- a/src/handlers/graphical/label.rs
+++ b/src/handlers/graphical/label.rs
@@ -29,39 +29,53 @@ struct Underline {
     underline: char,
 }
 
-fn write_repeated_char(f: &mut impl fmt::Write, c: char, mut count: usize) -> fmt::Result {
-    const CHUNK_CHARS: usize = 32;
-    const SPACES: &str = "                                ";
-    const UNICODE_BARS: &str = "────────────────────────────────";
-    const ASCII_CARETS: &str = "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^";
+const CHUNK_CHARS: usize = 64;
+const SPACES: &str =
+    concat!("                                ", "                                ");
+const UNICODE_BARS: &str =
+    concat!("────────────────────────────────", "────────────────────────────────");
+const ASCII_CARETS: &str =
+    concat!("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^", "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
 
-    // Built-in themes repeat these characters frequently, so emit them in chunks.
-    // Preserve the general character loop for custom themes.
-    let chunk = match c {
-        ' ' => SPACES,
-        '─' => UNICODE_BARS,
-        '^' => ASCII_CARETS,
-        _ => {
-            for _ in 0..count {
-                f.write_char(c)?;
-            }
-            return Ok(());
-        }
-    };
-
-    while count >= CHUNK_CHARS {
+fn write_repeated_chunk(
+    f: &mut impl fmt::Write,
+    chunk: &str,
+    char_len: usize,
+    mut count: usize,
+) -> fmt::Result {
+    while count > CHUNK_CHARS {
         f.write_str(chunk)?;
         count -= CHUNK_CHARS;
     }
-    f.write_str(&chunk[..count * c.len_utf8()])
+    if count == 0 { Ok(()) } else { f.write_str(&chunk[..count * char_len]) }
+}
+
+fn write_repeated_char(f: &mut impl fmt::Write, c: char, count: usize) -> fmt::Result {
+    for _ in 0..count {
+        f.write_char(c)?;
+    }
+    Ok(())
 }
 
 impl fmt::Display for Underline {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write_repeated_char(f, ' ', self.padding)?;
-        write_repeated_char(f, self.underline, self.left)?;
+        // Built-in themes repeat these characters frequently, so emit them in chunks.
+        // Preserve the original character loop for custom themes.
+        let Some((underline_chunk, char_len)) = (match self.underline {
+            '─' => Some((UNICODE_BARS, '─'.len_utf8())),
+            '^' => Some((ASCII_CARETS, 1)),
+            _ => None,
+        }) else {
+            write_repeated_char(f, ' ', self.padding)?;
+            write_repeated_char(f, self.underline, self.left)?;
+            f.write_char(self.marker)?;
+            return write_repeated_char(f, self.underline, self.right);
+        };
+
+        write_repeated_chunk(f, SPACES, 1, self.padding)?;
+        write_repeated_chunk(f, underline_chunk, char_len, self.left)?;
         f.write_char(self.marker)?;
-        write_repeated_char(f, self.underline, self.right)
+        write_repeated_chunk(f, underline_chunk, char_len, self.right)
     }
 }
 
@@ -358,7 +372,16 @@ mod tests {
         for c in [' ', '─', '^', 'x', '🐂'] {
             for count in [0, 1, 31, 32, 33, 64, 65] {
                 let mut output = String::new();
-                write_repeated_char(&mut output, c, count).unwrap();
+                if let Some((chunk, char_len)) = match c {
+                    ' ' => Some((SPACES, 1)),
+                    '─' => Some((UNICODE_BARS, '─'.len_utf8())),
+                    '^' => Some((ASCII_CARETS, 1)),
+                    _ => None,
+                } {
+                    write_repeated_chunk(&mut output, chunk, char_len, count).unwrap();
+                } else {
+                    write_repeated_char(&mut output, c, count).unwrap();
+                }
                 assert_eq!(output, c.to_string().repeat(count));
             }
         }


### PR DESCRIPTION
Write built-in underline runs in chunks to reduce formatter calls while preserving the custom-theme fallback.

CodSpeed records +2.6% monochrome, +2.0% colored, and +0.5% multi-label on the small fixture; all remain below the project threshold.