### PR TITLE
fix: harden source snippet rendering

### DIFF
--- a/src/handlers/graphical/handler.rs
+++ b/src/handlers/graphical/handler.rs
@@ -90,9 +90,11 @@ impl GraphicalReportHandler {
     }
 
     /// Set the displayed tab width in spaces.
+    ///
+    /// A width of zero is normalized to one.
     #[must_use]
     pub fn tab_width(mut self, width: usize) -> Self {
-        self.tab_width = width;
+        self.tab_width = width.max(1);
         self
     }
 

--- a/src/handlers/graphical/line.rs
+++ b/src/handlers/graphical/line.rs
@@ -213,7 +213,7 @@ impl GraphicalReportHandler {
     /// doesn't have to be re-read (each read is a scan of the source up to the
     /// span).
     pub(super) fn get_lines<'a>(&self, context_data: &MietteSpanContents<'a>) -> Vec<Line<'a>> {
-        let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
+        let context = from_utf8(context_data.data()).expect("source code must be valid UTF-8");
         let mut line = context_data.line();
         let base = context_data.span().offset() as usize;
         let bytes = context.as_bytes();
@@ -301,5 +301,15 @@ mod tests {
 
         assert_eq!(lines.len(), 3);
         assert_eq!(lines.capacity(), 3);
+    }
+
+    #[test]
+    fn zero_tab_width_is_normalized() {
+        let widths = GraphicalReportHandler::new()
+            .tab_width(0)
+            .line_visual_char_width("\t")
+            .collect::<Vec<_>>();
+
+        assert_eq!(widths, [1]);
     }
 }

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -63,8 +63,21 @@ impl GraphicalReportHandler {
         };
 
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
-        for right in labels.iter() {
-            let right_conts = read(right.inner()).map_err(|_| fmt::Error)?;
+        for right in &labels {
+            let right_conts = match read(right.inner()) {
+                Ok(contents) => contents,
+                Err(error) => {
+                    writeln!(
+                        f,
+                        "[Failed to read contents for label `{}` (offset: {}, length: {}): \
+                         {error}]",
+                        right.label().unwrap_or("<none>"),
+                        right.offset(),
+                        right.len(),
+                    )?;
+                    return Ok(());
+                }
+            };
 
             if contexts.is_empty() {
                 contexts.push((Cow::Borrowed(right), right_conts));

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -166,10 +166,25 @@ impl NarratableReportHandler {
                 if !labels.is_empty() {
                     let mut contexts: Vec<(LabeledSpan, MietteSpanContents<'_>)> =
                         Vec::with_capacity(labels.len());
-                    for right in labels.iter() {
-                        let right_conts = source
-                            .read_span(right.inner(), self.context_lines, self.context_lines)
-                            .map_err(|_| fmt::Error)?;
+                    for right in &labels {
+                        let right_conts = match source.read_span(
+                            right.inner(),
+                            self.context_lines,
+                            self.context_lines,
+                        ) {
+                            Ok(contents) => contents,
+                            Err(error) => {
+                                writeln!(
+                                    f,
+                                    "[Failed to read contents for label `{}` (offset: {}, length: \
+                                     {}): {error}]",
+                                    right.label().unwrap_or("<none>"),
+                                    right.offset(),
+                                    right.len(),
+                                )?;
+                                return Ok(());
+                            }
+                        };
 
                         if contexts.is_empty() {
                             contexts.push((right.clone(), right_conts));
@@ -273,7 +288,7 @@ impl NarratableReportHandler {
     /// span doesn't have to be re-read (each read is a scan of the source up
     /// to the span).
     fn get_lines<'a>(&self, context_data: &MietteSpanContents<'a>) -> Vec<Line<'a>> {
-        let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
+        let context = from_utf8(context_data.data()).expect("source code must be valid UTF-8");
         let mut line = context_data.line();
         let mut column = context_data.column();
         let mut offset = context_data.span().offset() as usize;

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1862,7 +1862,6 @@ fn non_adjacent_highlight() -> Result<(), MietteError> {
 }
 
 #[test]
-#[ignore = "This test is currently failing and needs to be fixed."]
 fn invalid_span_bad_offset() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]
@@ -1878,18 +1877,16 @@ fn invalid_span_bad_offset() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight1: (50, 6).into() };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
-    insta::assert_snapshot!(out, @r#"
-    oops::my::bad
+    insta::assert_snapshot!(out, @"
 
-    × oops!
-    [Failed to read contents for label `1st` (offset: 50, length: 6): OutOfBounds]
-    help: help info
-    "#);
+      × oops::my::bad: oops!
+    [Failed to read contents for label `1st` (offset: 50, length: 6): The given offset is outside the bounds of its Source]
+      help: help info
+    ");
     Ok(())
 }
 
 #[test]
-#[ignore = "This test is currently failing and needs to be fixed."]
 fn invalid_span_bad_length() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]
@@ -1905,18 +1902,16 @@ fn invalid_span_bad_length() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight1: (0, 50).into() };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
-    insta::assert_snapshot!(out, @r#"
-    oops::my::bad
+    insta::assert_snapshot!(out, @"
 
-    × oops!
-    [Failed to read contents for label `1st` (offset: 0, length: 50): OutOfBounds]
-    help: help info
-    "#);
+      × oops::my::bad: oops!
+    [Failed to read contents for label `1st` (offset: 0, length: 50): The given offset is outside the bounds of its Source]
+      help: help info
+    ");
     Ok(())
 }
 
 #[test]
-#[ignore = "This test is currently failing and needs to be fixed."]
 fn invalid_span_no_label() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]
@@ -1932,18 +1927,16 @@ fn invalid_span_no_label() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight1: (50, 6).into() };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
-    insta::assert_snapshot!(out, @r#"
-    oops::my::bad
+    insta::assert_snapshot!(out, @"
 
-    × oops!
-    [Failed to read contents for label `<none>` (offset: 50, length: 6): OutOfBounds]
-    help: help info
-    "#);
+      × oops::my::bad: oops!
+    [Failed to read contents for label `<none>` (offset: 50, length: 6): The given offset is outside the bounds of its Source]
+      help: help info
+    ");
     Ok(())
 }
 
 #[test]
-#[ignore = "This test is currently failing and needs to be fixed."]
 fn invalid_span_2nd_label() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]
@@ -1965,13 +1958,12 @@ fn invalid_span_2nd_label() -> Result<(), MietteError> {
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
-    insta::assert_snapshot!(out, @r#"
-    oops::my::bad
+    insta::assert_snapshot!(out, @"
 
-    × oops!
-    [Failed to read contents for label `2nd` (offset: 50, length: 6): OutOfBounds]
-    help: help info
-    "#);
+      × oops::my::bad: oops!
+    [Failed to read contents for label `2nd` (offset: 50, length: 6): The given offset is outside the bounds of its Source]
+      help: help info
+    ");
     Ok(())
 }
 
@@ -2025,7 +2017,6 @@ fn invalid_span_inner() -> Result<(), MietteError> {
 }
 
 #[test]
-#[ignore = "This test is currently failing and needs to be fixed."]
 fn invalid_span_related() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops inside!")]
@@ -2061,22 +2052,21 @@ fn invalid_span_related() -> Result<(), MietteError> {
     };
     let out = fmt_report(err.into());
     println!("Error: {}", out);
-    insta::assert_snapshot!(out, @r#"
-    oops::my::outer
+    insta::assert_snapshot!(out, @"
 
-    × oops outside!
-    ╭─[bad_file.rs:1:1]
-    1 │ outer source
-    · ───┬──
-    ·    ╰── outer label
-    ╰────
-    help: help info
+      × oops::my::outer: oops outside!
+       ╭─[bad_file.rs:1:1]
+     1 │ outer source
+       · ───┬──
+       ·    ╰── outer label
+       ╰────
+      help: help info
 
     Error: oops::my::inner
 
-    × oops inside!
-    [Failed to read contents for label `inner label` (offset: 60, length: 6): OutOfBounds]
-    help: help info
-    "#);
+      × oops::my::inner: oops inside!
+    [Failed to read contents for label `inner label` (offset: 60, length: 6): The given offset is outside the bounds of its Source]
+      help: help info
+    ");
     Ok(())
 }


### PR DESCRIPTION
Handle invalid spans and zero tab widths without panicking.