### PR TITLE
fix: preserve standard error sources

### DIFF
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -4,10 +4,11 @@
     clippy::new_ret_no_self,
     clippy::wrong_self_convention
 )]
-//! Autoref-specialization dispatch for `miette!(expr)`: picks up the argument's
-//! [`std::error::Error`] impl when it has one, otherwise falls back to
-//! `Display + Debug`. Vendored from [eyre](https://docs.rs/eyre) / anyhow; the
-//! comment below explains the mechanism in detail.
+//! Autoderef-specialization dispatch for `miette!(expr)`: picks up the argument's
+//! [`Diagnostic`] metadata when available, then an [`std::error::Error`]
+//! source chain, and otherwise falls back to `Display + Debug`. Vendored from
+//! [eyre](https://docs.rs/eyre) / anyhow; the comment below explains the
+//! mechanism in detail.
 
 // Tagged dispatch mechanism for resolving the behavior of `miette!($expr)`.
 //
@@ -40,27 +41,56 @@
 //         }
 //     }
 //
-// Since specialization is not stable yet, instead we rely on autoref behavior
-// of method resolution to perform tagged dispatch. Here we have two traits
-// AdhocKind and TraitKind that both have an miette_kind() method. AdhocKind is
-// implemented whether or not the caller's type has a std error impl, while
-// TraitKind is implemented only when a std error impl does exist. The ambiguity
-// is resolved by AdhocKind requiring an extra autoref so that it has lower
-// precedence.
+// Since specialization is not stable yet, instead we rely on autoderef behavior
+// of method resolution to perform tagged dispatch. TraitKind handles values
+// that already convert into Report, StdErrorKind handles other standard errors,
+// and AdhocKind is the fallback. The dispatch wrapper dereferences through these
+// cases in priority order, so method resolution picks the first applicable one.
 //
 // The miette! macro will set up the call in this form:
 //
 //     #[allow(unused_imports)]
-//     use $crate::private::{AdhocKind, TraitKind};
+//     use $crate::private::kind::*;
 //     let error = $msg;
-//     (&error).miette_kind().new(error)
+//     dispatch(&error).miette_kind().new(error)
 
-use core::fmt::{Debug, Display};
+use core::{
+    error::Error as StdError,
+    fmt::{Debug, Display},
+    ops::Deref,
+};
 
 use crate::Diagnostic;
 use crate::Report;
 
 pub struct Adhoc;
+
+pub struct Dispatch<T>(StdErrorDispatch<T>);
+
+pub struct StdErrorDispatch<T>(AdhocDispatch<T>);
+
+pub struct AdhocDispatch<T>(T);
+
+#[inline]
+pub fn dispatch<T>(value: &T) -> Dispatch<&T> {
+    Dispatch(StdErrorDispatch(AdhocDispatch(value)))
+}
+
+impl<T> Deref for Dispatch<T> {
+    type Target = StdErrorDispatch<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> Deref for StdErrorDispatch<T> {
+    type Target = AdhocDispatch<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 pub trait AdhocKind: Sized {
     #[inline]
@@ -69,7 +99,7 @@ pub trait AdhocKind: Sized {
     }
 }
 
-impl<T> AdhocKind for &T where T: ?Sized + Display + Debug + Send + Sync + 'static {}
+impl<T> AdhocKind for AdhocDispatch<&T> where T: Display + Debug + Send + Sync + 'static {}
 
 impl Adhoc {
     #[track_caller]
@@ -90,7 +120,7 @@ pub trait TraitKind: Sized {
     }
 }
 
-impl<E> TraitKind for E where E: Into<Report> {}
+impl<E> TraitKind for Dispatch<&E> where E: Into<Report> {}
 
 impl Trait {
     #[track_caller]
@@ -99,6 +129,27 @@ impl Trait {
         E: Into<Report>,
     {
         error.into()
+    }
+}
+
+pub struct StdErrorTag;
+
+pub trait StdErrorKind: Sized {
+    #[inline]
+    fn miette_kind(&self) -> StdErrorTag {
+        StdErrorTag
+    }
+}
+
+impl<E> StdErrorKind for StdErrorDispatch<&E> where E: StdError + Send + Sync + 'static {}
+
+impl StdErrorTag {
+    #[track_caller]
+    pub fn new<E>(self, error: E) -> Report
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        Report::from_std_error(error)
     }
 }
 
@@ -111,7 +162,7 @@ pub trait BoxedKind: Sized {
     }
 }
 
-impl BoxedKind for Box<dyn Diagnostic + Send + Sync> {}
+impl BoxedKind for Dispatch<&Box<dyn Diagnostic + Send + Sync>> {}
 
 impl Boxed {
     #[track_caller]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -239,7 +239,7 @@ macro_rules! miette {
     ($err:expr_2021 $(,)?) => ({
         use $crate::private::kind::*;
         let error = $err;
-        (&error).miette_kind().new(error)
+        dispatch(&error).miette_kind().new(error)
     });
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -229,7 +229,7 @@ pub mod private {
 
     #[doc(hidden)]
     pub mod kind {
-        pub use crate::kind::{AdhocKind, BoxedKind, TraitKind};
+        pub use crate::kind::{AdhocKind, BoxedKind, StdErrorKind, TraitKind, dispatch};
     }
 
     #[must_use]

--- a/src/report_impl.rs
+++ b/src/report_impl.rs
@@ -146,6 +146,30 @@ impl Report {
     }
 
     #[track_caller]
+    pub(crate) fn from_std_error<E>(error: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        use crate::wrapper::StdErrorWrapper;
+        let error = StdErrorWrapper(error);
+        let vtable = &ErrorVTable {
+            object_drop: object_drop::<StdErrorWrapper<E>>,
+            object_ref: object_ref::<StdErrorWrapper<E>>,
+            object_ref_stderr: object_ref_stderr::<E>,
+            object_boxed: object_boxed::<StdErrorWrapper<E>>,
+            object_boxed_stderr: object_boxed_stderr::<StdErrorWrapper<E>>,
+            object_downcast: object_downcast::<E>,
+            object_drop_rest: object_drop_front::<E>,
+        };
+
+        // Safety: StdErrorWrapper is repr(transparent) so it is okay for the
+        // vtable to allow casting the StdErrorWrapper<E> to E.
+        let handler = Some(crate::report::capture_handler(&error));
+
+        unsafe { Report::construct(error, vtable, handler) }
+    }
+
+    #[track_caller]
     pub(crate) fn from_boxed(error: Box<dyn Diagnostic + Send + Sync>) -> Self {
         use crate::wrapper::BoxedError;
         let error = BoxedError(error);

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,6 +1,7 @@
 //! The wrapper error types [`Report`](crate::Report) builds on: `MessageError`
-//! (an adhoc `Display`/`Debug` message), `BoxedError` (a boxed `Diagnostic`),
-//! and `WithSourceCode` (attaches source code to an error). Vendored from
+//! (an adhoc `Display`/`Debug` message), `StdErrorWrapper` (a standard error
+//! without diagnostic metadata), `BoxedError` (a boxed `Diagnostic`), and
+//! `WithSourceCode` (attaches source code to an error). Vendored from
 //! eyre/anyhow's `wrapper.rs`.
 
 use core::fmt::{self, Debug, Display};
@@ -32,6 +33,29 @@ where
 
 impl<M> StdError for MessageError<M> where M: Display + Debug + 'static {}
 impl<M> Diagnostic for MessageError<M> where M: Display + Debug + 'static {}
+
+#[repr(transparent)]
+pub(crate) struct StdErrorWrapper<E>(pub(crate) E);
+
+impl<E: Debug> Debug for StdErrorWrapper<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl<E: Display> Display for StdErrorWrapper<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl<E: StdError + 'static> StdError for StdErrorWrapper<E> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.0.source()
+    }
+}
+
+impl<E: StdError + 'static> Diagnostic for StdErrorWrapper<E> {}
 
 #[repr(transparent)]
 pub(crate) struct BoxedError(pub(crate) Box<dyn Diagnostic + Send + Sync>);

--- a/tests/test_source.rs
+++ b/tests/test_source.rs
@@ -51,9 +51,18 @@ fn test_fmt_source() {
 }
 
 #[test]
-#[ignore = "Again with the io::Error source issue?"]
 fn test_io_source() {
     let io = io::Error::other("oh no!");
     let error: Report = miette!(TestError::Io(io));
     assert_eq!("oh no!", error.source().unwrap().to_string());
+    assert!(error.is::<TestError>());
+    assert!(matches!(error.downcast::<TestError>(), Ok(TestError::Io(_))));
+}
+
+#[test]
+fn test_std_error_identity() {
+    let error: Report = miette!(io::Error::other("oh no!"));
+
+    assert!(error.chain().next().unwrap().is::<io::Error>());
+    assert!(error.root_cause().is::<io::Error>());
 }


### PR DESCRIPTION
Preserve standard error source chains and downcasting through report conversion.