### PR TITLE
fix: resolve renamed derive dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,9 +403,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
@@ -422,9 +431,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -578,9 +587,12 @@ dependencies = [
 name = "oxc-miette-derive"
 version = "3.0.1"
 dependencies = [
+ "cfg-expr",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 3.0.1",
+ "toml_edit",
 ]
 
 [[package]]
@@ -594,6 +606,15 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -799,6 +820,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -944,25 +971,37 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.8+spec-1.1.0"
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "winnow",
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1187,6 +1226,15 @@ name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -16,6 +16,9 @@ doctest = false
 
 [dependencies]
 # Relaxed version so the user can decide which version to use.
+cfg-expr = "0.20"
 proc-macro2 = "1"
+proc-macro-crate = "3.5"
 quote = "1"
 syn = "3"
+toml_edit = { version = "0.25", features = ["parse"], default-features = false }

--- a/miette-derive/src/lib.rs
+++ b/miette-derive/src/lib.rs
@@ -1,6 +1,10 @@
 use diagnostic::Diagnostic;
+use proc_macro_crate::{FoundCrate, crate_name};
+use proc_macro2::Span;
 use quote::quote;
-use syn::{DeriveInput, parse_macro_input};
+use std::path::{Path, PathBuf};
+use syn::{DeriveInput, Ident, parse_macro_input};
+use toml_edit::{DocumentMut, TableLike};
 
 mod code;
 mod diagnostic;
@@ -16,16 +20,236 @@ mod source_code;
 mod url;
 mod utils;
 
+fn dependency_names_package(
+    key: &str,
+    dependency: &toml_edit::Item,
+    package: &str,
+    workspace_dependencies: Option<&dyn TableLike>,
+) -> bool {
+    let dependency = dependency.as_table_like();
+    if let Some(declared_package) =
+        dependency.and_then(|dependency| dependency.get("package")?.as_str())
+    {
+        return declared_package == package;
+    }
+
+    let inherited =
+        dependency.and_then(|dependency| dependency.get("workspace")?.as_bool()).unwrap_or(false);
+    if inherited {
+        return workspace_dependencies.and_then(|dependencies| dependencies.get(key)).is_some_and(
+            |dependency| {
+                dependency
+                    .as_table_like()
+                    .and_then(|dependency| dependency.get("package")?.as_str())
+                    .unwrap_or(key)
+                    == package
+            },
+        );
+    }
+
+    key == package
+}
+
+fn dependency_key_in_section(
+    table: &dyn TableLike,
+    section: &str,
+    package: &str,
+    workspace_dependencies: Option<&dyn TableLike>,
+) -> Option<String> {
+    table.get(section)?.as_table_like()?.iter().find_map(|(key, dependency)| {
+        dependency_names_package(key, dependency, package, workspace_dependencies)
+            .then(|| key.to_owned())
+    })
+}
+
+fn target_dependency_keys_in_section(
+    manifest: &DocumentMut,
+    section: &str,
+    package: &str,
+    workspace_dependencies: Option<&dyn TableLike>,
+) -> Vec<(String, String)> {
+    manifest
+        .get("target")
+        .and_then(toml_edit::Item::as_table_like)
+        .into_iter()
+        .flat_map(TableLike::iter)
+        .filter_map(|(target, table)| {
+            let key = dependency_key_in_section(
+                table.as_table_like()?,
+                section,
+                package,
+                workspace_dependencies,
+            )?;
+            Some((target.to_owned(), key))
+        })
+        .collect()
+}
+
+fn workspace_dependencies(manifest: &DocumentMut) -> Option<&dyn TableLike> {
+    manifest.get("workspace")?.as_table_like()?.get("dependencies")?.as_table_like()
+}
+
+fn read_manifest(path: &Path) -> Option<DocumentMut> {
+    std::fs::read_to_string(path).ok()?.parse().ok()
+}
+
+fn inherited_workspace_manifest(
+    manifest_dir: &Path,
+    manifest: &DocumentMut,
+) -> Option<DocumentMut> {
+    if let Some(workspace) = manifest
+        .get("package")
+        .and_then(toml_edit::Item::as_table_like)
+        .and_then(|package| package.get("workspace"))
+        .and_then(toml_edit::Item::as_str)
+    {
+        return read_manifest(&manifest_dir.join(workspace).join("Cargo.toml"));
+    }
+
+    manifest_dir.parent()?.ancestors().find_map(|ancestor| {
+        let manifest = read_manifest(&ancestor.join("Cargo.toml"))?;
+        manifest.get("workspace").is_some().then_some(manifest)
+    })
+}
+
+fn target_cfg(target: &str) -> Option<proc_macro2::TokenStream> {
+    if let Some(cfg) = target.strip_prefix("cfg(").and_then(|cfg| cfg.strip_suffix(')')) {
+        return cfg.parse().ok();
+    }
+
+    let target = cfg_expr::targets::get_builtin_target_by_triple(target)?;
+    let arch = target.arch.as_str();
+    let os = target.os.as_ref().map_or("none", cfg_expr::targets::Os::as_str);
+    let abi = target.abi.as_ref().map_or("", cfg_expr::targets::Abi::as_str);
+    let env = target.env.as_ref().map_or("", cfg_expr::targets::Env::as_str);
+    let vendor = target.vendor.as_ref().map_or("unknown", cfg_expr::targets::Vendor::as_str);
+    let pointer_width = target.pointer_width.to_string();
+    let endian = match target.endian {
+        cfg_expr::targets::Endian::big => "big",
+        cfg_expr::targets::Endian::little => "little",
+    };
+    Some(quote! {
+        all(
+            target_arch = #arch,
+            target_os = #os,
+            target_abi = #abi,
+            target_env = #env,
+            target_vendor = #vendor,
+            target_pointer_width = #pointer_width,
+            target_endian = #endian
+        )
+    })
+}
+
+fn dependency_is_available(key: &str) -> bool {
+    let key = if key == "oxc-miette" { "miette".to_owned() } else { key.replace('-', "_") };
+    let mut arguments = std::env::args();
+    while let Some(argument) = arguments.next() {
+        let external = if argument == "--extern" {
+            arguments.next()
+        } else {
+            argument.strip_prefix("--extern=").map(str::to_owned)
+        };
+        if external.as_deref().and_then(|external| external.split('=').next()) == Some(&key) {
+            return true;
+        }
+    }
+    false
+}
+
+fn manifest_dependency_import(
+    manifest: &DocumentMut,
+    package: &str,
+    sections: &[&str],
+    workspace_dependencies: Option<&dyn TableLike>,
+) -> Option<proc_macro2::TokenStream> {
+    sections.iter().find_map(|section| {
+        if let Some(key) =
+            dependency_key_in_section(manifest.as_table(), section, package, workspace_dependencies)
+        {
+            let path = dependency_path(&key);
+            return Some(quote!(use #path as miette;));
+        }
+
+        let dependencies =
+            target_dependency_keys_in_section(manifest, section, package, workspace_dependencies);
+        if let Some((_, key)) = dependencies.iter().find(|(_, key)| dependency_is_available(key)) {
+            let path = dependency_path(key);
+            return Some(quote!(use #path as miette;));
+        }
+
+        let imports = dependencies
+            .into_iter()
+            .filter_map(|(target, key)| {
+                let cfg = target_cfg(&target)?;
+                let path = dependency_path(&key);
+                Some(quote! {
+                    #[cfg(#cfg)]
+                    use #path as miette;
+                })
+            })
+            .collect::<Vec<_>>();
+        (!imports.is_empty()).then(|| quote!(#(#imports)*))
+    })
+}
+
+fn current_manifest_dependency_import(package: &str) -> Option<proc_macro2::TokenStream> {
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR")?);
+    let manifest = read_manifest(&manifest_dir.join("Cargo.toml"))?;
+    let workspace_manifest = inherited_workspace_manifest(&manifest_dir, &manifest);
+    let workspace_dependencies = workspace_dependencies(&manifest)
+        .or_else(|| workspace_manifest.as_ref().and_then(workspace_dependencies));
+    let sections = if std::env::var("CARGO_CRATE_NAME").as_deref() == Ok("build_script_build") {
+        &["build-dependencies"][..]
+    } else {
+        &["dependencies", "dev-dependencies"][..]
+    };
+    manifest_dependency_import(&manifest, package, sections, workspace_dependencies)
+}
+
+fn dependency_path(key: &str) -> proc_macro2::TokenStream {
+    if key == "oxc-miette" {
+        return quote!(::miette);
+    }
+    let ident = Ident::new(&key.replace('-', "_"), Span::call_site());
+    quote!(::#ident)
+}
+
 #[proc_macro_derive(
     Diagnostic,
     attributes(diagnostic, source_code, label, related, help, diagnostic_source)
 )]
 pub fn derive_diagnostic(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+    let miette_import = if std::env::var("CARGO_PKG_NAME").as_deref() == Ok("oxc-miette") {
+        quote!(
+            use ::miette;
+        )
+    } else if let Some(import) = current_manifest_dependency_import("oxc-miette") {
+        import
+    } else {
+        match crate_name("oxc-miette") {
+            Ok(FoundCrate::Itself) => quote!(
+                use crate as miette;
+            ),
+            Ok(FoundCrate::Name(name)) => {
+                let ident = Ident::new(&name, Span::call_site());
+                quote!(use ::#ident as miette;)
+            }
+            Err(_) => quote!(
+                use ::miette;
+            ),
+        }
+    };
     let cmd = match Diagnostic::from_derive_input(input) {
         Ok(cmd) => cmd.r#gen(),
         Err(err) => return err.to_compile_error().into(),
     };
-    // panic!("{:#}", cmd.to_token_stream());
-    quote!(#cmd).into()
+    quote! {
+        const _: () = {
+            #miette_import
+            #cmd
+        };
+    }
+    .into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,6 +736,8 @@
 //! [`Result`]: https://docs.rs/miette/latest/miette/type.Result.html
 //! [`SourceCode`]: https://docs.rs/miette/latest/miette/trait.SourceCode.html
 //! [`SourceSpan`]: https://docs.rs/miette/latest/miette/struct.SourceSpan.html
+extern crate self as miette;
+
 pub use error::*;
 #[cfg(feature = "fancy-base")]
 pub use handler::*;

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -3,7 +3,7 @@ use std::{env, fmt::Write, mem::size_of, panic::set_hook};
 use backtrace::Backtrace;
 use thiserror::Error;
 
-use crate::{self as miette, Diagnostic, Report};
+use crate::{Diagnostic, Report};
 
 /// Tells miette to render panics using its rendering engine.
 pub fn set_panic_hook() {


### PR DESCRIPTION
Resolve the runtime crate path when the dependency is renamed.