### PR TITLE
refactor: mark value-returning APIs as must use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ unsafe_op_in_unsafe_fn = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
 
 [lints.clippy]
+must_use_candidate = "warn"
+return_self_not_must_use = "warn"
 undocumented_unsafe_blocks = "warn"
 
 [dependencies]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -55,6 +55,7 @@ pub struct MietteHandlerOpts {
 
 impl MietteHandlerOpts {
     /// Create a new `MietteHandlerOpts`.
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }
@@ -62,6 +63,7 @@ impl MietteHandlerOpts {
     /// If true, specify whether the graphical handler will make codes be
     /// clickable links in supported terminals. Defaults to auto-detection
     /// based on known supported terminals.
+    #[must_use]
     pub fn terminal_links(mut self, linkify: bool) -> Self {
         self.linkify = Some(linkify);
         self
@@ -71,12 +73,14 @@ impl MietteHandlerOpts {
     /// Use [`force_graphical()`](`MietteHandlerOpts::force_graphical) to force
     /// graphical mode. This option overrides
     /// [`color()`](`MietteHandlerOpts::color).
+    #[must_use]
     pub fn graphical_theme(mut self, theme: GraphicalTheme) -> Self {
         self.theme = Some(theme);
         self
     }
 
     /// Sets the width to wrap the report at. Defaults to 80.
+    #[must_use]
     pub fn width(mut self, width: usize) -> Self {
         self.width = Some(width);
         self
@@ -87,6 +91,7 @@ impl MietteHandlerOpts {
     /// If false, long lines will not be broken when they exceed the width.
     ///
     /// Defaults to true.
+    #[must_use]
     pub fn wrap_lines(mut self, wrap_lines: bool) -> Self {
         self.wrap_lines = Some(wrap_lines);
         self
@@ -97,30 +102,35 @@ impl MietteHandlerOpts {
     /// If false, long words will not be broken when they exceed the width.
     ///
     /// Defaults to true.
+    #[must_use]
     pub fn break_words(mut self, break_words: bool) -> Self {
         self.break_words = Some(break_words);
         self
     }
 
     /// Sets the `textwrap::WordSeparator` to use when determining wrap points.
+    #[must_use]
     pub fn word_separator(mut self, word_separator: textwrap::WordSeparator) -> Self {
         self.word_separator = Some(word_separator);
         self
     }
 
     /// Sets the `textwrap::WordSplitter` to use when determining wrap points.
+    #[must_use]
     pub fn word_splitter(mut self, word_splitter: textwrap::WordSplitter) -> Self {
         self.word_splitter = Some(word_splitter);
         self
     }
 
     /// Include the cause chain of the top-level error in the report.
+    #[must_use]
     pub fn with_cause_chain(mut self) -> Self {
         self.with_cause_chain = Some(true);
         self
     }
 
     /// Do not include the cause chain of the top-level error in the report.
+    #[must_use]
     pub fn without_cause_chain(mut self) -> Self {
         self.with_cause_chain = Some(false);
         self
@@ -135,6 +145,7 @@ impl MietteHandlerOpts {
     ///
     /// The actual format depends on the value of
     /// [`MietteHandlerOpts::rgb_colors`].
+    #[must_use]
     pub fn color(mut self, color: bool) -> Self {
         self.color = Some(color);
         self
@@ -149,6 +160,7 @@ impl MietteHandlerOpts {
     /// first place. That is handled by the [`MietteHandlerOpts::color`]
     /// setting. If colors are not being used, the value of `rgb_colors` has
     /// no effect.
+    #[must_use]
     pub fn rgb_colors(mut self, color: RgbColors) -> Self {
         self.rgb_colors = color;
         self
@@ -156,6 +168,7 @@ impl MietteHandlerOpts {
 
     /// If true, forces unicode display for graphical output. If set to false,
     /// forces ASCII art display.
+    #[must_use]
     pub fn unicode(mut self, unicode: bool) -> Self {
         self.unicode = Some(unicode);
         self
@@ -163,36 +176,42 @@ impl MietteHandlerOpts {
 
     /// If true, graphical rendering will be used regardless of terminal
     /// detection.
+    #[must_use]
     pub fn force_graphical(mut self, force: bool) -> Self {
         self.force_graphical = Some(force);
         self
     }
 
     /// If true, forces use of the narrated renderer.
+    #[must_use]
     pub fn force_narrated(mut self, force: bool) -> Self {
         self.force_narrated = Some(force);
         self
     }
 
     /// Set a footer to be displayed at the bottom of the report.
+    #[must_use]
     pub fn footer(mut self, footer: String) -> Self {
         self.footer = Some(footer);
         self
     }
 
     /// Sets the number of context lines before and after a span to display.
+    #[must_use]
     pub fn context_lines(mut self, context_lines: usize) -> Self {
         self.context_lines = Some(context_lines);
         self
     }
 
     /// Set the displayed tab width in spaces.
+    #[must_use]
     pub fn tab_width(mut self, width: usize) -> Self {
         self.tab_width = Some(width);
         self
     }
 
     /// Builds a [`MietteHandler`] from this builder.
+    #[must_use]
     pub fn build(self) -> MietteHandler {
         let graphical = self.is_graphical();
         let width = self.get_width();
@@ -309,6 +328,7 @@ pub struct MietteHandler {
 
 impl MietteHandler {
     /// Creates a new [`MietteHandler`] with default settings.
+    #[must_use]
     pub fn new() -> Self {
         Default::default()
     }

--- a/src/handlers/debug.rs
+++ b/src/handlers/debug.rs
@@ -13,6 +13,7 @@ pub struct DebugReportHandler;
 impl DebugReportHandler {
     /// Create a new [`NarratableReportHandler`](crate::NarratableReportHandler)
     /// There are no customization options.
+    #[must_use]
     pub const fn new() -> Self {
         Self
     }

--- a/src/handlers/graphical/handler.rs
+++ b/src/handlers/graphical/handler.rs
@@ -53,6 +53,7 @@ pub(crate) enum LinkStyle {
 impl GraphicalReportHandler {
     /// Create a new `GraphicalReportHandler` with the default
     /// [`GraphicalTheme`]. This will use both unicode characters and colors.
+    #[must_use]
     pub fn new() -> Self {
         let is_terminal = io::stdout().is_terminal() && io::stderr().is_terminal();
         Self {
@@ -71,6 +72,7 @@ impl GraphicalReportHandler {
     }
 
     /// Create a new `GraphicalReportHandler` with a given [`GraphicalTheme`].
+    #[must_use]
     pub fn new_themed(theme: GraphicalTheme) -> Self {
         Self {
             links: LinkStyle::Link,
@@ -97,54 +99,63 @@ impl GraphicalReportHandler {
     }
 
     /// Whether to enable error code linkification using [`Diagnostic::url()`](crate::Diagnostic::url).
+    #[must_use]
     pub fn with_links(mut self, links: bool) -> Self {
         self.links = if links { LinkStyle::Link } else { LinkStyle::Text };
         self
     }
 
     /// Set a theme for this handler.
+    #[must_use]
     pub fn with_theme(mut self, theme: GraphicalTheme) -> Self {
         self.theme = theme;
         self
     }
 
     /// Sets the width to wrap the report at.
+    #[must_use]
     pub fn with_width(mut self, width: usize) -> Self {
         self.termwidth = width;
         self
     }
 
     /// Enables or disables wrapping of lines to fit the width.
+    #[must_use]
     pub fn with_wrap_lines(mut self, wrap_lines: bool) -> Self {
         self.wrap_lines = wrap_lines;
         self
     }
 
     /// Enables or disables breaking of words during wrapping.
+    #[must_use]
     pub fn with_break_words(mut self, break_words: bool) -> Self {
         self.break_words = break_words;
         self
     }
 
     /// Sets the word separator to use when wrapping.
+    #[must_use]
     pub fn with_word_separator(mut self, word_separator: textwrap::WordSeparator) -> Self {
         self.word_separator = Some(word_separator);
         self
     }
 
-    /// Sets the word splitter to usewhen wrapping.
+    /// Sets the word splitter to use when wrapping.
+    #[must_use]
     pub fn with_word_splitter(mut self, word_splitter: textwrap::WordSplitter) -> Self {
         self.word_splitter = Some(word_splitter);
         self
     }
 
     /// Sets the 'global' footer for this handler.
+    #[must_use]
     pub fn with_footer(mut self, footer: String) -> Self {
         self.footer = Some(footer);
         self
     }
 
     /// Sets the number of lines of context to show around each error.
+    #[must_use]
     pub fn with_context_lines(mut self, lines: usize) -> Self {
         self.context_lines = lines;
         self
@@ -152,6 +163,7 @@ impl GraphicalReportHandler {
 
     /// Sets the display text for links.
     /// Miette displays `(link)` if this option is not set.
+    #[must_use]
     pub fn with_link_display_text(mut self, text: impl Into<String>) -> Self {
         self.link_display_text = Some(text.into());
         self

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -14,6 +14,7 @@ pub struct JSONReportHandler;
 impl JSONReportHandler {
     /// Create a new [`JSONReportHandler`]. There are no customization
     /// options.
+    #[must_use]
     pub const fn new() -> Self {
         Self
     }

--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -43,6 +43,8 @@ impl Default for GraphicalTheme {
 }
 
 impl GraphicalTheme {
+    /// Chooses a graphical theme based on terminal and environment support.
+    #[must_use]
     pub fn new(is_terminal: bool) -> Self {
         if force_color() {
             return Self::unicode();
@@ -55,6 +57,7 @@ impl GraphicalTheme {
     }
 
     /// ASCII-art-based graphical drawing, with ANSI styling.
+    #[must_use]
     pub fn ascii() -> Self {
         Self { characters: ThemeCharacters::ascii(), styles: ThemeStyles::ansi() }
     }
@@ -67,12 +70,14 @@ impl GraphicalTheme {
     /// that can change the background color and make hardcoded colors illegible.
     /// Such themes typically remap ansi codes properly, treating them more
     /// like CSS classes than specific colors.
+    #[must_use]
     pub fn unicode() -> Self {
         Self { characters: ThemeCharacters::unicode(), styles: ThemeStyles::rgb() }
     }
 
     /// Graphical theme that draws in monochrome, while still using unicode
     /// characters.
+    #[must_use]
     pub fn unicode_nocolor() -> Self {
         Self { characters: ThemeCharacters::unicode(), styles: ThemeStyles::none() }
     }
@@ -82,6 +87,7 @@ impl GraphicalTheme {
     /// rendering of your [`Diagnostic`](crate::Diagnostic)s, check out
     /// [`NarratableReportHandler`](crate::NarratableReportHandler), or write
     /// your own [`ReportHandler`](crate::ReportHandler)
+    #[must_use]
     pub fn none() -> Self {
         Self { characters: ThemeCharacters::ascii(), styles: ThemeStyles::none() }
     }
@@ -119,6 +125,7 @@ fn style() -> Style {
 impl ThemeStyles {
     /// Nice RGB colors.
     /// [Credit](http://terminal.sexy/#FRUV0NDQFRUVrEFCkKlZ9L91ap-1qnWfdbWq0NDQUFBQrEFCkKlZ9L91ap-1qnWfdbWq9fX1).
+    #[must_use]
     pub fn rgb() -> Self {
         Self {
             error: style().fg_rgb::<225, 80, 80>().bold(), // CHANGED: <255, 30, 30>
@@ -137,6 +144,7 @@ impl ThemeStyles {
     }
 
     /// ANSI color-based styles.
+    #[must_use]
     pub fn ansi() -> Self {
         Self {
             error: style().red(),
@@ -155,6 +163,7 @@ impl ThemeStyles {
     }
 
     /// No styling. Just regular ol' monochrome.
+    #[must_use]
     pub fn none() -> Self {
         Self {
             error: style(),
@@ -209,6 +218,7 @@ pub struct ThemeCharacters {
 
 impl ThemeCharacters {
     /// Fancy unicode-based graphical elements.
+    #[must_use]
     pub fn unicode() -> Self {
         Self {
             hbar: '─',
@@ -236,6 +246,7 @@ impl ThemeCharacters {
     }
 
     /// Emoji-heavy unicode characters.
+    #[must_use]
     pub fn emoji() -> Self {
         Self {
             hbar: '─',
@@ -263,6 +274,7 @@ impl ThemeCharacters {
     }
 
     /// ASCII-art-based graphical elements. Works well on older terminals.
+    #[must_use]
     pub fn ascii() -> Self {
         Self {
             hbar: '-',

--- a/src/macro_helpers.rs
+++ b/src/macro_helpers.rs
@@ -14,6 +14,7 @@ impl<T> IsOption for Option<T> {}
 pub struct OptionalWrapper<T>(pub PhantomData<T>);
 
 impl<T> OptionalWrapper<T> {
+    #[must_use]
     pub fn new() -> Self {
         Self(PhantomData)
     }

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -25,6 +25,7 @@ impl<S: SourceCode> fmt::Debug for NamedSource<S> {
 impl<S: SourceCode + 'static> NamedSource<S> {
     /// Create a new `NamedSource` using a regular [`SourceCode`] and giving
     /// its returned [`SpanContents`] a name.
+    #[must_use]
     pub fn new(name: impl AsRef<str>, source: S) -> Self
     where
         S: Send + Sync,
@@ -33,12 +34,14 @@ impl<S: SourceCode + 'static> NamedSource<S> {
     }
 
     /// Gets the name of this `NamedSource`.
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// Returns a reference the inner [`SourceCode`] type for this
     /// `NamedSource`.
+    #[must_use]
     pub fn inner(&self) -> &S {
         &self.source
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -439,6 +439,7 @@ impl LabeledSpan {
     ///     LabeledSpan::new(Some("expected a closing parenthesis".to_string()), 4, 0)
     /// )
     /// ```
+    #[must_use]
     pub fn at_offset(offset: ByteOffset, label: impl Into<String>) -> Self {
         Self::new(Some(label.into()), offset, 0)
     }
@@ -459,21 +460,25 @@ impl LabeledSpan {
     }
 
     /// Gets the (optional) label string for this `LabeledSpan`.
+    #[must_use]
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()
     }
 
     /// Returns a reference to the inner [`SourceSpan`].
+    #[must_use]
     pub const fn inner(&self) -> &SourceSpan {
         &self.span
     }
 
     /// Returns the 0-based starting byte offset.
+    #[must_use]
     pub const fn offset(&self) -> ByteOffset {
         self.span.offset()
     }
 
     /// Returns the number of bytes this `LabeledSpan` spans.
+    #[must_use]
     pub const fn len(&self) -> u32 {
         self.span.len()
     }
@@ -483,11 +488,13 @@ impl LabeledSpan {
     }
 
     /// True if this `LabeledSpan` is empty.
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.span.is_empty()
     }
 
     /// True if this `LabeledSpan` is a primary span.
+    #[must_use]
     pub const fn primary(&self) -> bool {
         self.primary
     }
@@ -549,6 +556,7 @@ pub struct MietteSpanContents<'a> {
 
 impl<'a> MietteSpanContents<'a> {
     /// Make a new [`MietteSpanContents`] object.
+    #[must_use]
     pub const fn new(
         data: &'a [u8],
         span: SourceSpan,
@@ -560,6 +568,7 @@ impl<'a> MietteSpanContents<'a> {
     }
 
     /// Make a new [`MietteSpanContents`] object, with a name for its 'file'.
+    #[must_use]
     pub const fn new_named(
         name: Cow<'a, str>,
         data: &'a [u8],
@@ -629,16 +638,19 @@ pub struct SourceSpan {
 
 impl SourceSpan {
     /// Create a new [`SourceSpan`].
+    #[must_use]
     pub const fn new(start: SourceOffset, length: u32) -> Self {
         Self { offset: start, length }
     }
 
     /// The absolute offset, in bytes, from the beginning of a [`SourceCode`].
+    #[must_use]
     pub const fn offset(&self) -> ByteOffset {
         self.offset.offset()
     }
 
     /// Total length of the [`SourceSpan`], in bytes.
+    #[must_use]
     pub const fn len(&self) -> u32 {
         self.length
     }
@@ -649,6 +661,7 @@ impl SourceSpan {
 
     /// Whether this [`SourceSpan`] has a length of zero. It may still be useful
     /// to point to a specific point.
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.length == 0
     }
@@ -698,6 +711,7 @@ pub struct SourceOffset(ByteOffset);
 
 impl SourceOffset {
     /// Actual byte offset.
+    #[must_use]
     pub const fn offset(&self) -> ByteOffset {
         self.0
     }
@@ -707,6 +721,7 @@ impl SourceOffset {
     ///
     /// This function is infallible: Giving an out-of-range line/column pair
     /// will return the offset of the last byte in the source.
+    #[must_use]
     pub fn from_location(source: impl AsRef<str>, loc_line: usize, loc_col: usize) -> Self {
         let mut line = 0usize;
         let mut col = 0usize;
@@ -734,7 +749,7 @@ impl SourceOffset {
     /// Returns both the filename that was given and the offset of the caller
     /// as a [`SourceOffset`].
     ///
-    /// Keep in mind that this fill only work if the file your Rust source
+    /// Keep in mind that this will only work if the file your Rust source
     /// file was compiled from is actually available at that location. If
     /// you're shipping binaries for your application, you'll want to ignore
     /// the Err case or otherwise report it.

--- a/src/report.rs
+++ b/src/report.rs
@@ -232,6 +232,7 @@ pub mod private {
         pub use crate::kind::{AdhocKind, BoxedKind, StdErrorKind, TraitKind, dispatch};
     }
 
+    #[must_use]
     #[track_caller]
     pub fn new_adhoc<M>(message: M) -> Report
     where

--- a/src/report_impl.rs
+++ b/src/report_impl.rs
@@ -33,6 +33,7 @@ impl Report {
     /// If the error type does not provide a backtrace, a backtrace will be
     /// created here to ensure that a backtrace exists.
     #[track_caller]
+    #[must_use]
     pub fn new<E>(error: E) -> Self
     where
         E: Diagnostic + Send + Sync + 'static,
@@ -78,6 +79,7 @@ impl Report {
     /// }
     /// ```
     #[track_caller]
+    #[must_use]
     pub fn msg<M>(message: M) -> Self
     where
         M: Display + Debug + Send + Sync + 'static,
@@ -93,6 +95,7 @@ impl Report {
     /// Boxed `Diagnostic`s don't implement `Diagnostic` themselves due to trait coherence issues.
     /// This method allows you to create a `Report` from a boxed `Diagnostic`.
     #[track_caller]
+    #[must_use]
     pub fn new_boxed(error: Box<dyn Diagnostic + Send + Sync + 'static>) -> Self {
         Report::from_boxed(error)
     }
@@ -235,6 +238,7 @@ impl Report {
     ///     None
     /// }
     /// ```
+    #[must_use]
     pub fn chain(&self) -> Chain<'_> {
         ErrorImpl::chain(self.inner.by_ref())
     }
@@ -244,6 +248,7 @@ impl Report {
     ///
     /// The root cause is the last error in the iterator produced by
     /// [`chain()`](Report::chain).
+    #[must_use]
     pub fn root_cause(&self) -> &(dyn StdError + 'static) {
         self.chain().next_back().unwrap()
     }
@@ -256,6 +261,7 @@ impl Report {
     /// interaction between message and downcasting, [see here].
     ///
     /// [see here]: trait.WrapErr.html#effect-on-downcasting
+    #[must_use]
     pub fn is<E>(&self) -> bool
     where
         E: Display + Debug + Send + Sync + 'static,
@@ -335,6 +341,7 @@ impl Report {
     /// }
     /// # ;
     /// ```
+    #[must_use]
     pub fn downcast_ref<E>(&self) -> Option<&E>
     where
         E: Display + Debug + Send + Sync + 'static,
@@ -369,6 +376,7 @@ impl Report {
     }
 
     /// Get a reference to the Handler for this Report.
+    #[must_use]
     pub fn handler(&self) -> &dyn ReportHandler {
         self.inner.by_ref().deref().handler.as_ref().unwrap().as_ref()
     }
@@ -379,6 +387,7 @@ impl Report {
     }
 
     /// Provide source code for this error
+    #[must_use]
     pub fn with_source_code(self, source_code: impl SourceCode + 'static) -> Report {
         WithSourceCode { source_code, error: self }.into()
     }


### PR DESCRIPTION
Mark constructors, getters, and builders whose return values should be used.