### PR TITLE
perf: isolate renderer error paths

### DIFF
--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
     Diagnostic, LabeledSpan, MietteSpanContents, SourceCode, SourceSpan, SpanContents,
-    handlers::snippets::{SnippetContext, merge_contexts},
+    handlers::snippets::{SnippetContext, merge_contexts, write_read_error},
     source_impls::SpanScanner,
 };
 
@@ -65,10 +65,7 @@ impl GraphicalReportHandler {
 
         let contexts = match merge_contexts(&labels, read) {
             Ok(contexts) => contexts,
-            Err(error) => {
-                writeln!(f, "[{error}]")?;
-                return Ok(());
-            }
+            Err(error) => return write_read_error(f, &error),
         };
         for SnippetContext { span, contents } in contexts {
             self.render_context(f, &span, contents, &labels[..])?;

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -5,7 +5,7 @@ use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 use crate::{
     LabeledSpan, MietteSpanContents, ReportHandler, SourceCode, SourceSpan, SpanContents,
     diagnostic_chain::DiagnosticChain,
-    handlers::snippets::{SnippetContext, merge_contexts},
+    handlers::snippets::{SnippetContext, merge_contexts, write_read_error},
     protocol::{Diagnostic, Severity},
 };
 
@@ -169,10 +169,7 @@ impl NarratableReportHandler {
                         source.read_span(span, self.context_lines, self.context_lines)
                     }) {
                         Ok(contexts) => contexts,
-                        Err(error) => {
-                            writeln!(f, "[{error}]")?;
-                            return Ok(());
-                        }
+                        Err(error) => return write_read_error(f, &error),
                     };
                     for SnippetContext { contents, .. } in contexts {
                         self.render_context(f, contents, &labels[..])?;

--- a/src/handlers/snippets.rs
+++ b/src/handlers/snippets.rs
@@ -28,6 +28,15 @@ impl<E: fmt::Display> fmt::Display for SnippetReadError<'_, E> {
     }
 }
 
+#[cold]
+#[inline(never)]
+pub(super) fn write_read_error(
+    formatter: &mut impl fmt::Write,
+    error: &impl fmt::Display,
+) -> fmt::Result {
+    writeln!(formatter, "[{error}]")
+}
+
 /// Reads sorted labels and combines source windows that overlap by line.
 pub(super) fn merge_contexts<'label, 'source, E>(
     labels: &'label [LabeledSpan],


### PR DESCRIPTION
Move rare renderer failures out of the normal success path.