### PR TITLE
docs: synchronize the documented MSRV

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,7 +693,7 @@
 //!
 //! ## MSRV
 //!
-//! This crate requires rustc 1.70.0 or later.
+//! This crate requires rustc 1.85.0 or later.
 //!
 //! ## Acknowledgements
 //!


### PR DESCRIPTION
Updates crate documentation to match the declared Rust 1.85 MSRV.