### PR TITLE
chore: sync Rust and Clippy lints

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,17 @@
 avoid-breaking-exported-api = false
+
+ignore-interior-mutability = ["oxc_linter::rules::RuleEnum"]
+
+disallowed-methods = [
+  { path = "str::to_ascii_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_lowercase` instead." },
+  { path = "str::to_ascii_uppercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_ascii_uppercase` instead." },
+  { path = "str::to_lowercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_lowercase` instead." },
+  { path = "str::to_uppercase", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_to_uppercase` instead." },
+  { path = "str::replace", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_replace` instead." },
+  { path = "str::replacen", reason = "To avoid memory allocation, use `cow_utils::CowUtils::cow_replacen` instead." },
+]
+
+disallowed-types = [
+  { path = "std::collections::HashMap", reason = "Use `rustc_hash::FxHashMap` instead, which is typically faster." },
+  { path = "std::collections::HashSet", reason = "Use `rustc_hash::FxHashSet` instead, which is typically faster." },
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,6 +580,7 @@ version = "3.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
+ "rustc-hash",
  "syn 3.0.1",
 ]
 
@@ -667,6 +668,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,125 @@ members = ["miette-derive"]
 [workspace.package]
 authors = ["Boshen", "Kat Marchán <kzm@zkat.tech>"]
 categories = ["rust-patterns"]
+keywords = ["diagnostics", "error-reporting", "terminal"]
+readme = "README.md"
 repository = "https://github.com/oxc-project/oxc-miette"
 license = "Apache-2.0"
 edition = "2024"
 rust-version = "1.85.0"
+
+# <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>
+[workspace.lints.rust]
+absolute_paths_not_starting_with_crate = "warn"
+non_ascii_idents = "warn"
+unit-bindings = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
+tail_expr_drop_order = "warn"
+unsafe_op_in_unsafe_fn = "warn"
+unused_unsafe = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+# restriction
+dbg_macro = "warn"
+todo = "warn"
+unimplemented = "warn"
+print_stdout = "warn" # Must be opt-in
+print_stderr = "warn" # Must be opt-in
+allow_attributes = "warn"
+# I like the explicitness of this rule as it removes confusion around `clone`.
+# This increases readability, avoids `clone` mindlessly and heap allocating by accident.
+clone_on_ref_ptr = "warn"
+# These two are mutually exclusive, I like `mod.rs` files for better fuzzy searches on module entries.
+self_named_module_files = "warn" # "-Wclippy::mod_module_files"
+empty_drop = "warn"
+empty_structs_with_brackets = "warn"
+empty_enum_variants_with_brackets = "warn"
+exit = "warn"
+# Performance: avoid the intermediate `String` allocation of `s.push_str(&format!(..))`.
+format_push_string = "warn"
+# Casting a function item/pointer to a number is almost always a mistake (a missing call).
+fn_to_numeric_cast_any = "warn"
+unnecessary_self_imports = "warn"
+# `return Err(x)?` obscures a plain `return Err(x.into())`.
+try_err = "warn"
+# Don't name a type `Error` when it implements `std::error::Error`.
+error_impl_error = "warn"
+filetype_is_file = "warn"
+get_unwrap = "warn"
+rc_buffer = "warn"
+rc_mutex = "warn"
+rest_pat_in_fully_bound_structs = "warn"
+unnecessary_safety_comment = "warn"
+undocumented_unsafe_blocks = "warn"
+infinite_loop = "warn"
+map_with_unused_argument_over_ranges = "warn"
+unused_result_ok = "warn"
+pathbuf_init_then_push = "warn"
+pub_underscore_fields = "warn"
+non_zero_suggestions = "warn"
+precedence_bits = "warn"
+# I want to write the best Rust code so pedantic is enabled.
+# We should only disable rules globally if they are either false positives, chaotic, or does not make sense.
+pedantic = { level = "warn", priority = -1 }
+# Allowed rules
+# pedantic
+# All triggers are mostly ignored in our codebase, so this is ignored globally.
+struct_excessive_bools = "allow"
+too_many_lines = "allow"
+# `#[must_use]` is creating too much noise for this codebase, it does not add much value
+# except nagging the programmer to add a `#[must_use]` after clippy has been run.
+# Having `#[must_use]` everywhere also hinders readability.
+must_use_candidate = "allow"
+# Preserve this repository's existing builder-return lint.
+return_self_not_must_use = "warn"
+# Too annoying, we import by name anyway.
+wildcard_imports = "allow"
+doc_markdown = "allow"
+similar_names = "allow"
+fn_params_excessive_bools = "allow"
+complexity = { level = "warn", priority = -1 }
+too_many_arguments = "allow"
+non_std_lazy_statics = "allow"
+# `OxcDiagnostic` is inlined (~176 bytes) to keep `OxcDiagnostic::error` allocation-free.
+# This is a deliberate trade-off: larger `Result<T, OxcDiagnostic>` for zero malloc on the hot path.
+result_large_err = "allow"
+# nursery
+nursery = { level = "warn", priority = -1 }
+# `const` functions do not make sense for our project because this is not a `const` library.
+# This rule also confuses newcomers and forces them to add `const` blindlessly without any reason.
+missing_const_for_fn = "allow"
+option_if_let_else = "allow"
+or_fun_call = "allow"
+cognitive_complexity = "allow"
+non_send_fields_in_send_ty = "allow"
+use_self = "allow"
+significant_drop_tightening = "allow"
+branches_sharing_code = "allow"
+fallible_impl_from = "allow"
+useless_let_if_seq = "allow"
+impl_trait_in_params = "allow"
+significant_drop_in_scrutinee = "warn"
+iter_on_single_items = "warn"
+unused_peekable = "warn"
+too_long_first_doc_paragraph = "warn"
+suspicious_operation_groupings = "warn"
+redundant_clone = "warn"
+# FIXME: New warnings introduced by Rust 1.97.
+byte_char_slices = "allow"
+question_mark = "allow"
+# cargo
+cargo = { level = "warn", priority = -1 }
+multiple_crate_versions = "allow"
+# Public feature retained for compatibility with existing users.
+negative_feature_names = "allow"
 
 [package]
 name = "oxc-miette"
 description = "Fancy diagnostic reporting library and protocol for us mere mortals who aren't compiler hackers."
 documentation = "https://docs.rs/oxc-miette"
 readme = "README.md"
+keywords.workspace = true
 version = "3.0.1"
 authors.workspace = true
 categories.workspace = true
@@ -35,15 +144,8 @@ harness = false
 test = false
 required-features = ["fancy"]
 
-[lints.rust]
-absolute_paths_not_starting_with_crate = "warn"
-non_ascii_idents = "warn"
-unit-bindings = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
-
-[lints.clippy]
-must_use_candidate = "warn"
-return_self_not_must_use = "warn"
+[lints]
+workspace = true
 
 [dependencies]
 oxc-miette-derive = { path = "miette-derive", version = "=3.0.1", optional = true }

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -1,3 +1,11 @@
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::cast_precision_loss,
+    clippy::cast_sign_loss,
+    clippy::print_stderr,
+    reason = "benchmark fixtures are bounded and progress output is intentional"
+)]
+
 //! Benchmarks for miette's diagnostic rendering pipeline.
 //!
 //! These mirror how oxc actually consumes this crate: oxlint and oxfmt build a

--- a/miette-derive/Cargo.toml
+++ b/miette-derive/Cargo.toml
@@ -4,6 +4,8 @@ description = "Derive macros for miette. Like `thiserror` for Diagnostics."
 version = "3.0.1"
 authors.workspace = true
 categories.workspace = true
+keywords.workspace = true
+readme.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
@@ -14,8 +16,12 @@ proc-macro = true
 test = false
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 # Relaxed version so the user can decide which version to use.
 proc-macro2 = "1"
 quote = "1"
+rustc-hash = "2"
 syn = "3"

--- a/miette-derive/src/code.rs
+++ b/miette-derive/src/code.rs
@@ -71,12 +71,12 @@ impl Code {
         )
     }
 
-    pub(crate) fn gen_struct(&self) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self) -> TokenStream {
         let code = &self.0;
-        Some(quote! {
+        quote! {
             fn code(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                 std::option::Option::Some(std::borrow::Cow::Borrowed(#code))
             }
-        })
+        }
     }
 }

--- a/miette-derive/src/diagnostic.rs
+++ b/miette-derive/src/diagnostic.rs
@@ -291,7 +291,7 @@ impl Diagnostic {
                         let code_body = concrete
                             .code
                             .as_ref()
-                            .map(super::code::Code::gen_struct)
+                            .map(Code::gen_struct)
                             .or_else(|| forward(WhichFn::Code));
                         let help_body = concrete
                             .help
@@ -301,12 +301,12 @@ impl Diagnostic {
                         let sev_body = concrete
                             .severity
                             .as_ref()
-                            .map(super::severity::Severity::gen_struct)
+                            .map(Severity::gen_struct)
                             .or_else(|| forward(WhichFn::Severity));
                         let rel_body = concrete
                             .related
                             .as_ref()
-                            .map(super::related::Related::gen_struct)
+                            .map(Related::gen_struct)
                             .or_else(|| forward(WhichFn::Related));
                         let url_body = concrete
                             .url
@@ -326,7 +326,7 @@ impl Diagnostic {
                         let diagnostic_source = concrete
                             .diagnostic_source
                             .as_ref()
-                            .map(super::diagnostic_source::DiagnosticSource::gen_struct)
+                            .map(DiagnosticSource::gen_struct)
                             .or_else(|| forward(WhichFn::DiagnosticSource));
                         quote! {
                             impl #impl_generics miette::Diagnostic for #ident #ty_generics #where_clause {

--- a/miette-derive/src/diagnostic.rs
+++ b/miette-derive/src/diagnostic.rs
@@ -75,10 +75,10 @@ pub struct DiagnosticConcreteArgs {
 impl DiagnosticConcreteArgs {
     fn for_fields(fields: &syn::Fields) -> Result<Self, syn::Error> {
         let labels = Labels::from_fields(fields)?;
-        let source_code = SourceCode::from_fields(fields)?;
-        let related = Related::from_fields(fields)?;
-        let help = Help::from_fields(fields)?;
-        let diagnostic_source = DiagnosticSource::from_fields(fields)?;
+        let source_code = SourceCode::from_fields(fields);
+        let related = Related::from_fields(fields);
+        let help = Help::from_fields(fields);
+        let diagnostic_source = DiagnosticSource::from_fields(fields);
         Ok(DiagnosticConcreteArgs {
             code: None,
             help,
@@ -154,6 +154,10 @@ impl DiagnosticDefArgs {
         attrs: &[&syn::Attribute],
         allow_transparent: bool,
     ) -> syn::Result<Self> {
+        fn is_transparent(d: &DiagnosticArg) -> bool {
+            matches!(d, DiagnosticArg::Transparent)
+        }
+
         let mut errors = Vec::new();
 
         // Handle the only condition where Transparent is allowed
@@ -174,10 +178,6 @@ impl DiagnosticDefArgs {
         } else {
             "diagnostic(transparent) not allowed here"
         };
-        fn is_transparent(d: &DiagnosticArg) -> bool {
-            matches!(d, DiagnosticArg::Transparent)
-        }
-
         let mut concrete = DiagnosticConcreteArgs::for_fields(fields)?;
         for attr in attrs {
             let args =
@@ -291,42 +291,42 @@ impl Diagnostic {
                         let code_body = concrete
                             .code
                             .as_ref()
-                            .and_then(|x| x.gen_struct())
+                            .map(super::code::Code::gen_struct)
                             .or_else(|| forward(WhichFn::Code));
                         let help_body = concrete
                             .help
                             .as_ref()
-                            .and_then(|x| x.gen_struct(fields))
+                            .map(|x| x.gen_struct(fields))
                             .or_else(|| forward(WhichFn::Help));
                         let sev_body = concrete
                             .severity
                             .as_ref()
-                            .and_then(|x| x.gen_struct())
+                            .map(super::severity::Severity::gen_struct)
                             .or_else(|| forward(WhichFn::Severity));
                         let rel_body = concrete
                             .related
                             .as_ref()
-                            .and_then(|x| x.gen_struct())
+                            .map(super::related::Related::gen_struct)
                             .or_else(|| forward(WhichFn::Related));
                         let url_body = concrete
                             .url
                             .as_ref()
-                            .and_then(|x| x.gen_struct(ident, fields))
+                            .map(|x| x.gen_struct(ident, fields))
                             .or_else(|| forward(WhichFn::Url));
                         let labels_body = concrete
                             .labels
                             .as_ref()
-                            .and_then(|x| x.gen_struct(fields))
+                            .map(|x| x.gen_struct(fields))
                             .or_else(|| forward(WhichFn::Labels));
                         let src_body = concrete
                             .source_code
                             .as_ref()
-                            .and_then(|x| x.gen_struct(fields))
+                            .map(|x| x.gen_struct(fields))
                             .or_else(|| forward(WhichFn::SourceCode));
                         let diagnostic_source = concrete
                             .diagnostic_source
                             .as_ref()
-                            .and_then(|x| x.gen_struct())
+                            .map(super::diagnostic_source::DiagnosticSource::gen_struct)
                             .or_else(|| forward(WhichFn::DiagnosticSource));
                         quote! {
                             impl #impl_generics miette::Diagnostic for #ident #ty_generics #where_clause {

--- a/miette-derive/src/diagnostic_source.rs
+++ b/miette-derive/src/diagnostic_source.rs
@@ -1,40 +1,23 @@
-use proc_macro2::TokenStream;
-use quote::quote;
-use syn::spanned::Spanned;
-
 use crate::{
     diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
     forward::WhichFn,
-    utils::{display_pat_members, gen_all_variants_with},
+    utils::{display_pat_members, field_member, gen_all_variants_with},
 };
+use proc_macro2::TokenStream;
+use quote::quote;
 
 pub struct DiagnosticSource(syn::Member);
 
 impl DiagnosticSource {
-    pub(crate) fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
-        match fields {
-            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
-            syn::Fields::Unnamed(unnamed) => {
-                Self::from_fields_vec(unnamed.unnamed.iter().collect())
-            }
-            syn::Fields::Unit => Ok(None),
-        }
-    }
-
-    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
+    pub(crate) fn from_fields(fields: &syn::Fields) -> Option<Self> {
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("diagnostic_source") {
-                    let diagnostic_source = if let Some(ident) = field.ident.clone() {
-                        syn::Member::Named(ident)
-                    } else {
-                        syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-                    };
-                    return Ok(Some(DiagnosticSource(diagnostic_source)));
+                    return Some(DiagnosticSource(field_member(i, field)));
                 }
             }
         }
-        Ok(None)
+        None
     }
 
     pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {
@@ -60,12 +43,12 @@ impl DiagnosticSource {
         )
     }
 
-    pub(crate) fn gen_struct(&self) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self) -> TokenStream {
         let rel = &self.0;
-        Some(quote! {
+        quote! {
             fn diagnostic_source<'a>(&'a self) -> std::option::Option<&'a dyn miette::Diagnostic> {
                 std::option::Option::Some(std::borrow::Borrow::borrow(&self.#rel))
             }
-        })
+        }
     }
 }

--- a/miette-derive/src/fmt.rs
+++ b/miette-derive/src/fmt.rs
@@ -1,8 +1,9 @@
 // NOTE: Most code in this file is taken straight from `thiserror`.
-use std::{collections::HashSet as Set, iter::FromIterator};
+use std::iter::FromIterator;
 
 use proc_macro2::{Delimiter, Group, TokenStream, TokenTree};
 use quote::{ToTokens, format_ident, quote, quote_spanned};
+use rustc_hash::FxHashSet;
 use syn::{
     Ident, Index, LitStr, Member, Result, Token, braced, bracketed,
     ext::IdentExt,
@@ -14,7 +15,6 @@ use syn::{
 pub struct Display {
     pub fmt: LitStr,
     pub args: TokenStream,
-    pub has_bonus_display: bool,
 }
 
 impl ToTokens for Display {
@@ -29,7 +29,7 @@ impl ToTokens for Display {
 
 impl Display {
     // Transform `"error {var}"` to `"error {}", var`.
-    pub fn expand_shorthand(&mut self, members: &Set<Member>) {
+    pub fn expand_shorthand(&mut self, members: &FxHashSet<Member>) {
         let raw_args = self.args.clone();
         let mut named_args = explicit_named_args.parse2(raw_args).unwrap();
 
@@ -38,8 +38,6 @@ impl Display {
         let mut read = fmt.as_str();
         let mut out = String::new();
         let mut args = self.args.clone();
-        let mut has_bonus_display = false;
-
         let mut has_trailing_comma = false;
         if let Some(TokenTree::Punct(punct)) = args.clone().into_iter().last() {
             if punct.as_char() == ',' {
@@ -48,17 +46,14 @@ impl Display {
         }
 
         while let Some(brace) = read.find('{') {
-            out += &read[..brace + 1];
+            out += &read[..=brace];
             read = &read[brace + 1..];
             if read.starts_with('{') {
                 out.push('{');
                 read = &read[1..];
                 continue;
             }
-            let next = match read.chars().next() {
-                Some(next) => next,
-                None => return,
-            };
+            let Some(next) = read.chars().next() else { return };
             let member = match next {
                 '0'..='9' => {
                     let int = take_int(&mut read);
@@ -102,7 +97,6 @@ impl Display {
             }
             args.extend(quote_spanned!(span=> #formatvar = #local));
             if read.starts_with('}') && members.contains(&member) {
-                has_bonus_display = true;
                 // args.extend(quote_spanned!(span=> .as_display()));
             }
             has_trailing_comma = false;
@@ -111,12 +105,11 @@ impl Display {
         out += read;
         self.fmt = LitStr::new(&out, self.fmt.span());
         self.args = args;
-        self.has_bonus_display = has_bonus_display;
     }
 }
 
-fn explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
-    let mut named_args = Set::new();
+fn explicit_named_args(input: ParseStream) -> Result<FxHashSet<Ident>> {
+    let mut named_args = FxHashSet::default();
 
     while !input.is_empty() {
         if input.peek(Token![,]) && input.peek2(Ident::peek_any) && input.peek3(Token![=]) {
@@ -135,12 +128,11 @@ fn explicit_named_args(input: ParseStream) -> Result<Set<Ident>> {
 fn take_int(read: &mut &str) -> String {
     let mut int = String::new();
     for (i, ch) in read.char_indices() {
-        match ch {
-            '0'..='9' => int.push(ch),
-            _ => {
-                *read = &read[i..];
-                break;
-            }
+        if let '0'..='9' = ch {
+            int.push(ch);
+        } else {
+            *read = &read[i..];
+            break;
         }
     }
     int

--- a/miette-derive/src/forward.rs
+++ b/miette-derive/src/forward.rs
@@ -44,7 +44,7 @@ pub enum WhichFn {
 }
 
 impl WhichFn {
-    pub fn method_call(&self) -> TokenStream {
+    pub fn method_call(self) -> TokenStream {
         match self {
             Self::Code => quote! { code() },
             Self::Help => quote! { help() },
@@ -57,7 +57,7 @@ impl WhichFn {
         }
     }
 
-    pub fn signature(&self) -> TokenStream {
+    pub fn signature(self) -> TokenStream {
         match self {
             Self::Code => quote! {
                 fn code(&self) -> std::option::Option<std::borrow::Cow<'_, str>>
@@ -86,7 +86,7 @@ impl WhichFn {
         }
     }
 
-    pub fn catchall_arm(&self) -> TokenStream {
+    pub fn catchall_arm(self) -> TokenStream {
         match self {
             Self::Labels => quote! { _ => miette::Labels::None },
             Self::Related => quote! { _ => miette::Related::None },
@@ -119,7 +119,7 @@ impl Forward {
                 }
                 Ok(Self::Unnamed(0))
             }
-            _ => Err(syn::Error::new(
+            syn::Fields::Unit => Err(syn::Error::new(
                 fields.span(),
                 "you cannot use #[diagnostic(transparent)] with a unit struct or a unit variant",
             )),

--- a/miette-derive/src/help.rs
+++ b/miette-derive/src/help.rs
@@ -3,14 +3,13 @@ use quote::{format_ident, quote};
 use syn::{
     Fields, Token, parenthesized,
     parse::{Parse, ParseStream},
-    spanned::Spanned,
 };
 
 use crate::{
     diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
     fmt::{self, Display},
     forward::WhichFn,
-    utils::{display_pat_members, gen_all_variants_with},
+    utils::{display_pat_members, field_member, gen_all_variants_with},
 };
 
 pub enum Help {
@@ -32,15 +31,11 @@ impl Parse for Help {
                 } else {
                     fmt::parse_token_expr(&content, false)?
                 };
-                let display = Display { fmt, args, has_bonus_display: false };
+                let display = Display { fmt, args };
                 Ok(Help::Display(display))
             } else {
                 input.parse::<Token![=]>()?;
-                Ok(Help::Display(Display {
-                    fmt: input.parse()?,
-                    args: TokenStream::new(),
-                    has_bonus_display: false,
-                }))
+                Ok(Help::Display(Display { fmt: input.parse()?, args: TokenStream::new() }))
             }
         } else {
             Err(syn::Error::new(ident.span(), "not a help"))
@@ -49,30 +44,15 @@ impl Parse for Help {
 }
 
 impl Help {
-    pub(crate) fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
-        match fields {
-            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
-            syn::Fields::Unnamed(unnamed) => {
-                Self::from_fields_vec(unnamed.unnamed.iter().collect())
-            }
-            syn::Fields::Unit => Ok(None),
-        }
-    }
-
-    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
+    pub(crate) fn from_fields(fields: &syn::Fields) -> Option<Self> {
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("help") {
-                    let help = if let Some(ident) = field.ident.clone() {
-                        syn::Member::Named(ident)
-                    } else {
-                        syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-                    };
-                    return Ok(Some(Help::Field(help, Box::new(field.ty.clone()))));
+                    return Some(Help::Field(field_member(i, field), Box::new(field.ty.clone())));
                 }
             }
         }
-        Ok(None)
+        None
     }
 
     pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {
@@ -108,29 +88,29 @@ impl Help {
         )
     }
 
-    pub(crate) fn gen_struct(&self, fields: &Fields) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self, fields: &Fields) -> TokenStream {
         let (display_pat, display_members) = display_pat_members(fields);
         match self {
             Help::Display(display) => {
                 let (fmt, args) = display.expand_shorthand_cloned(&display_members);
-                Some(quote! {
+                quote! {
                     fn help(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                         #[allow(unused_variables, deprecated)]
                         let Self #display_pat = self;
                         std::option::Option::Some(std::borrow::Cow::Owned(format!(#fmt #args)))
                     }
-                })
+                }
             }
             Help::Field(member, ty) => {
                 let var = quote! { __miette_internal_var };
-                Some(quote! {
+                quote! {
                     fn help(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                         #[allow(unused_variables, deprecated)]
                         let Self #display_pat = self;
                         use miette::macro_helpers::ToOption;
                         miette::macro_helpers::OptionalWrapper::<#ty>::new().to_option(&self.#member).as_ref().map(|#var| -> std::borrow::Cow<'_, str> { std::borrow::Cow::Owned(format!("{}", #var)) })
                     }
-                })
+                }
             }
         }
     }

--- a/miette-derive/src/label.rs
+++ b/miette-derive/src/label.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::{ToTokens, format_ident, quote};
 use syn::{
     Token, parenthesized,
     parse::{Parse, ParseStream},
@@ -10,7 +10,7 @@ use crate::{
     diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
     fmt::{self, Display},
     forward::WhichFn,
-    utils::{display_pat_members, gen_all_variants_with},
+    utils::{display_pat_members, field_member, gen_all_variants_with},
 };
 
 pub struct Labels(Vec<Label>);
@@ -23,7 +23,7 @@ enum LabelType {
 }
 
 struct Label {
-    label: Option<Display>,
+    display: Option<Display>,
     ty: syn::Type,
     span: syn::Member,
     lbl_ty: LabelType,
@@ -78,7 +78,7 @@ impl Parse for LabelAttr {
                 } else {
                     fmt::parse_token_expr(&content, false)?
                 };
-                let display = Display { fmt, args, has_bonus_display: false };
+                let display = Display { fmt, args };
                 (attr, Some(display))
             } else if !content.is_empty() {
                 return Err(syn::Error::new(
@@ -91,14 +91,7 @@ impl Parse for LabelAttr {
         } else if la.peek(Token![=]) {
             // #[label = "blabla"]
             input.parse::<Token![=]>()?;
-            (
-                LabelType::Default,
-                Some(Display {
-                    fmt: input.parse()?,
-                    args: TokenStream::new(),
-                    has_bonus_display: false,
-                }),
-            )
+            (LabelType::Default, Some(Display { fmt: input.parse()?, args: TokenStream::new() }))
         } else {
             (LabelType::Default, None)
         };
@@ -108,26 +101,11 @@ impl Parse for LabelAttr {
 
 impl Labels {
     pub fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
-        match fields {
-            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
-            syn::Fields::Unnamed(unnamed) => {
-                Self::from_fields_vec(unnamed.unnamed.iter().collect())
-            }
-            syn::Fields::Unit => Ok(None),
-        }
-    }
-
-    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
         let mut labels = Vec::new();
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("label") {
-                    let span = if let Some(ident) = field.ident.clone() {
-                        syn::Member::Named(ident)
-                    } else {
-                        syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-                    };
-                    use quote::ToTokens;
+                    let span = field_member(i, field);
                     let LabelAttr { label, lbl_ty } =
                         syn::parse2::<LabelAttr>(attr.meta.to_token_stream())?;
 
@@ -140,22 +118,22 @@ impl Labels {
                         ));
                     }
 
-                    labels.push(Label { label, span, ty: field.ty.clone(), lbl_ty });
+                    labels.push(Label { display: label, span, ty: field.ty.clone(), lbl_ty });
                 }
             }
         }
         if labels.is_empty() { Ok(None) } else { Ok(Some(Labels(labels))) }
     }
 
-    pub(crate) fn gen_struct(&self, fields: &syn::Fields) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self, fields: &syn::Fields) -> TokenStream {
         let (display_pat, display_members) = display_pat_members(fields);
         let labels = self.0.iter().filter_map(|highlight| {
-            let Label { span, label, ty, lbl_ty } = highlight;
+            let Label { span, display, ty, lbl_ty } = highlight;
             if *lbl_ty == LabelType::Collection {
                 return None;
             }
             let var = quote! { __miette_internal_var };
-            let display = if let Some(display) = label {
+            let display = if let Some(display) = display {
                 let (fmt, args) = display.expand_shorthand_cloned(&display_members);
                 quote! { std::option::Option::Some(format!(#fmt #args)) }
             } else {
@@ -176,11 +154,11 @@ impl Labels {
             })
         });
         let collections_chain = self.0.iter().filter_map(|label| {
-            let Label { span, label, ty: _, lbl_ty } = label;
+            let Label { span, display, ty: _, lbl_ty } = label;
             if *lbl_ty != LabelType::Collection {
                 return None;
             }
-            let display = if let Some(display) = label {
+            let display = if let Some(display) = display {
                 let (fmt, args) = display.expand_shorthand_cloned(&display_members);
                 quote! { std::option::Option::Some(format!(#fmt #args)) }
             } else {
@@ -201,7 +179,7 @@ impl Labels {
             })
         });
 
-        Some(quote! {
+        quote! {
             #[allow(unused_variables)]
             fn labels(&self) -> miette::Labels {
                 use miette::macro_helpers::ToOption;
@@ -215,7 +193,7 @@ impl Labels {
 
                 labels_iter.filter(Option::is_some).map(Option::unwrap).collect()
             }
-        })
+        }
     }
 
     pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {
@@ -226,7 +204,7 @@ impl Labels {
                 let (display_pat, display_members) = display_pat_members(fields);
                 labels.as_ref().and_then(|labels| {
                     let variant_labels = labels.0.iter().filter_map(|label| {
-                        let Label { span, label, ty, lbl_ty } = label;
+                        let Label { span, display, ty, lbl_ty } = label;
                         if *lbl_ty == LabelType::Collection {
                             return None;
                         }
@@ -237,7 +215,7 @@ impl Labels {
                             }
                         };
                         let var = quote! { __miette_internal_var };
-                        let display = if let Some(display) = label {
+                        let display = if let Some(display) = display {
                             let (fmt, args) = display.expand_shorthand_cloned(&display_members);
                             quote! { std::option::Option::Some(format!(#fmt #args)) }
                         } else {
@@ -258,7 +236,7 @@ impl Labels {
                         })
                     });
                     let collections_chain = labels.0.iter().filter_map(|label| {
-                        let Label { span, label, ty: _, lbl_ty } = label;
+                        let Label { span, display, ty: _, lbl_ty } = label;
                         if *lbl_ty != LabelType::Collection {
                             return None;
                         }
@@ -268,7 +246,7 @@ impl Labels {
                                 format_ident!("_{}", index)
                             }
                         };
-                        let display = if let Some(display) = label {
+                        let display = if let Some(display) = display {
                             let (fmt, args) = display.expand_shorthand_cloned(&display_members);
                             quote! { std::option::Option::Some(format!(#fmt #args)) }
                         } else {

--- a/miette-derive/src/related.rs
+++ b/miette-derive/src/related.rs
@@ -1,40 +1,23 @@
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-use syn::spanned::Spanned;
-
 use crate::{
     diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
     forward::WhichFn,
-    utils::{display_pat_members, gen_all_variants_with},
+    utils::{display_pat_members, field_member, gen_all_variants_with},
 };
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 
 pub struct Related(syn::Member);
 
 impl Related {
-    pub(crate) fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
-        match fields {
-            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
-            syn::Fields::Unnamed(unnamed) => {
-                Self::from_fields_vec(unnamed.unnamed.iter().collect())
-            }
-            syn::Fields::Unit => Ok(None),
-        }
-    }
-
-    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
+    pub(crate) fn from_fields(fields: &syn::Fields) -> Option<Self> {
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("related") {
-                    let related = if let Some(ident) = field.ident.clone() {
-                        syn::Member::Named(ident)
-                    } else {
-                        syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-                    };
-                    return Ok(Some(Related(related)));
+                    return Some(Related(field_member(i, field)));
                 }
             }
         }
-        Ok(None)
+        None
     }
 
     pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {
@@ -60,13 +43,13 @@ impl Related {
         )
     }
 
-    pub(crate) fn gen_struct(&self) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self) -> TokenStream {
         let rel = &self.0;
-        Some(quote! {
+        quote! {
             fn related(&self) -> miette::Related<'_> {
                 use ::core::borrow::Borrow;
                 self.#rel.iter().map(|x| -> &(dyn miette::Diagnostic) { &*x.borrow() }).collect()
             }
-        })
+        }
     }
 }

--- a/miette-derive/src/severity.rs
+++ b/miette-derive/src/severity.rs
@@ -44,14 +44,20 @@ impl Parse for Severity {
 }
 
 fn get_severity(input: &str, span: Span) -> syn::Result<String> {
-    match input.to_lowercase().as_ref() {
-        "error" | "err" => Ok("Error".into()),
-        "warning" | "warn" => Ok("Warning".into()),
-        "advice" | "adv" | "info" => Ok("Advice".into()),
-        _ => Err(syn::Error::new(
+    if input.eq_ignore_ascii_case("error") || input.eq_ignore_ascii_case("err") {
+        Ok("Error".into())
+    } else if input.eq_ignore_ascii_case("warning") || input.eq_ignore_ascii_case("warn") {
+        Ok("Warning".into())
+    } else if input.eq_ignore_ascii_case("advice")
+        || input.eq_ignore_ascii_case("adv")
+        || input.eq_ignore_ascii_case("info")
+    {
+        Ok("Advice".into())
+    } else {
+        Err(syn::Error::new(
             span,
             "Invalid severity level. Only Error, Warning, and Advice are supported.",
-        )),
+        ))
     }
 }
 
@@ -74,12 +80,12 @@ impl Severity {
         )
     }
 
-    pub(crate) fn gen_struct(&self) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self) -> TokenStream {
         let sev = &self.0;
-        Some(quote! {
+        quote! {
             fn severity(&self) -> std::option::Option<miette::Severity> {
                 Some(miette::Severity::#sev)
             }
-        })
+        }
     }
 }

--- a/miette-derive/src/source_code.rs
+++ b/miette-derive/src/source_code.rs
@@ -1,12 +1,10 @@
-use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
-use syn::spanned::Spanned;
-
 use crate::{
     diagnostic::{DiagnosticConcreteArgs, DiagnosticDef},
     forward::WhichFn,
-    utils::{display_pat_members, gen_all_variants_with},
+    utils::{display_pat_members, field_member, gen_all_variants_with},
 };
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
 
 pub struct SourceCode {
     source_code: syn::Member,
@@ -14,17 +12,7 @@ pub struct SourceCode {
 }
 
 impl SourceCode {
-    pub fn from_fields(fields: &syn::Fields) -> syn::Result<Option<Self>> {
-        match fields {
-            syn::Fields::Named(named) => Self::from_fields_vec(named.named.iter().collect()),
-            syn::Fields::Unnamed(unnamed) => {
-                Self::from_fields_vec(unnamed.unnamed.iter().collect())
-            }
-            syn::Fields::Unit => Ok(None),
-        }
-    }
-
-    fn from_fields_vec(fields: Vec<&syn::Field>) -> syn::Result<Option<Self>> {
+    pub fn from_fields(fields: &syn::Fields) -> Option<Self> {
         for (i, field) in fields.iter().enumerate() {
             for attr in &field.attrs {
                 if attr.path().is_ident("source_code") {
@@ -33,24 +21,19 @@ impl SourceCode {
                         ..
                     }) = &field.ty
                     {
-                        segments.last().map(|seg| seg.ident == "Option").unwrap_or(false)
+                        segments.last().is_some_and(|seg| seg.ident == "Option")
                     } else {
                         false
                     };
 
-                    let source_code = if let Some(ident) = field.ident.clone() {
-                        syn::Member::Named(ident)
-                    } else {
-                        syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-                    };
-                    return Ok(Some(SourceCode { source_code, is_option }));
+                    return Some(SourceCode { source_code: field_member(i, field), is_option });
                 }
             }
         }
-        Ok(None)
+        None
     }
 
-    pub(crate) fn gen_struct(&self, fields: &syn::Fields) -> Option<TokenStream> {
+    pub(crate) fn gen_struct(&self, fields: &syn::Fields) -> TokenStream {
         let (display_pat, _display_members) = display_pat_members(fields);
         let src = &self.source_code;
         let ret = if self.is_option {
@@ -63,13 +46,13 @@ impl SourceCode {
             }
         };
 
-        Some(quote! {
+        quote! {
             #[allow(unused_variables)]
             fn source_code(&self) -> std::option::Option<&dyn miette::SourceCode> {
                 let Self #display_pat = self;
                 #ret
             }
-        })
+        }
     }
 
     pub(crate) fn gen_enum(variants: &[DiagnosticDef]) -> Option<TokenStream> {

--- a/miette-derive/src/url.rs
+++ b/miette-derive/src/url.rs
@@ -32,7 +32,7 @@ impl Parse for Url {
                     } else {
                         fmt::parse_token_expr(&content, false)?
                     };
-                    let display = Display { fmt, args, has_bonus_display: false };
+                    let display = Display { fmt, args };
                     Ok(Url::Display(display))
                 } else {
                     let option = content.parse::<syn::Ident>()?;
@@ -47,11 +47,7 @@ impl Parse for Url {
                 }
             } else {
                 input.parse::<Token![=]>()?;
-                Ok(Url::Display(Display {
-                    fmt: input.parse()?,
-                    args: TokenStream::new(),
-                    has_bonus_display: false,
-                }))
+                Ok(Url::Display(Display { fmt: input.parse()?, args: TokenStream::new() }))
             }
         } else {
             Err(syn::Error::new(ident.span(), "not a url"))
@@ -60,6 +56,10 @@ impl Parse for Url {
 }
 
 impl Url {
+    #[expect(
+        clippy::literal_string_with_formatting_args,
+        reason = "this string becomes the format template emitted by the derive macro"
+    )]
     pub(crate) fn gen_enum(
         enum_name: &syn::Ident,
         variants: &[DiagnosticDef],
@@ -98,11 +98,11 @@ impl Url {
         )
     }
 
-    pub(crate) fn gen_struct(
-        &self,
-        struct_name: &syn::Ident,
-        fields: &Fields,
-    ) -> Option<TokenStream> {
+    #[expect(
+        clippy::literal_string_with_formatting_args,
+        reason = "this string becomes the format template emitted by the derive macro"
+    )]
+    pub(crate) fn gen_struct(&self, struct_name: &syn::Ident, fields: &Fields) -> TokenStream {
         let (pat, fmt, args) = match self {
             Url::Display(display) => {
                 let (display_pat, display_members) = display_pat_members(fields);
@@ -124,12 +124,12 @@ impl Url {
                 (pat, fmt, args)
             }
         };
-        Some(quote! {
+        quote! {
             fn url(&self) -> std::option::Option<std::borrow::Cow<'_, str>> {
                 #[allow(unused_variables, deprecated)]
                 let Self #pat = self;
                 std::option::Option::Some(std::borrow::Cow::Owned(format!(#fmt #args)))
             }
-        })
+        }
     }
 }

--- a/miette-derive/src/utils.rs
+++ b/miette-derive/src/utils.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use rustc_hash::FxHashSet;
 use syn::spanned::Spanned;
 
 use crate::{
@@ -7,7 +8,7 @@ use crate::{
     forward::WhichFn,
 };
 
-pub(crate) fn gen_all_variants_with(
+pub fn gen_all_variants_with(
     variants: &[DiagnosticDef],
     which_fn: WhichFn,
     mut f: impl FnMut(&syn::Ident, &syn::Fields, &DiagnosticConcreteArgs) -> Option<TokenStream>,
@@ -36,11 +37,20 @@ pub(crate) fn gen_all_variants_with(
     })
 }
 
-use std::collections::HashSet;
-
 use crate::fmt::Display;
 
-pub(crate) fn gen_unused_pat(fields: &syn::Fields) -> TokenStream {
+pub fn field_member(index: usize, field: &syn::Field) -> syn::Member {
+    if let Some(ident) = field.ident.clone() {
+        syn::Member::Named(ident)
+    } else {
+        syn::Member::Unnamed(syn::Index {
+            index: u32::try_from(index).expect("field index exceeds u32::MAX"),
+            span: field.span(),
+        })
+    }
+}
+
+pub fn gen_unused_pat(fields: &syn::Fields) -> TokenStream {
     match fields {
         syn::Fields::Named(_) => quote! { { .. } },
         syn::Fields::Unnamed(_) => quote! { ( .. ) },
@@ -54,7 +64,7 @@ fn gen_fields_pat(fields: &syn::Fields) -> TokenStream {
     let member_idents = fields
         .iter()
         .enumerate()
-        .map(|(i, field)| field.ident.as_ref().cloned().unwrap_or_else(|| format_ident!("_{}", i)));
+        .map(|(i, field)| field.ident.clone().unwrap_or_else(|| format_ident!("_{}", i)));
     match fields {
         syn::Fields::Named(_) => quote! {
             { #(#member_idents),* }
@@ -69,19 +79,9 @@ fn gen_fields_pat(fields: &syn::Fields) -> TokenStream {
 /// The returned tokens go in the slot `let Self #pat = self;` or `match self {
 /// Self #pat => ... }`. The members can be passed to
 /// `Display::expand_shorthand[_cloned]`.
-pub(crate) fn display_pat_members(fields: &syn::Fields) -> (TokenStream, HashSet<syn::Member>) {
+pub fn display_pat_members(fields: &syn::Fields) -> (TokenStream, FxHashSet<syn::Member>) {
     let pat = gen_fields_pat(fields);
-    let members: HashSet<syn::Member> = fields
-        .iter()
-        .enumerate()
-        .map(|(i, field)| {
-            if let Some(ident) = field.ident.as_ref().cloned() {
-                syn::Member::Named(ident)
-            } else {
-                syn::Member::Unnamed(syn::Index { index: i as u32, span: field.span() })
-            }
-        })
-        .collect();
+    let members = fields.iter().enumerate().map(|(i, field)| field_member(i, field)).collect();
     (pat, members)
 }
 
@@ -90,11 +90,11 @@ impl Display {
     /// without tokens in between, i.e. `format!(#fmt #args)`.
     pub(crate) fn expand_shorthand_cloned(
         &self,
-        members: &HashSet<syn::Member>,
+        members: &FxHashSet<syn::Member>,
     ) -> (syn::LitStr, TokenStream) {
         let mut display = self.clone();
         display.expand_shorthand(members);
-        let Display { fmt, args, .. } = display;
+        let Display { fmt, args } = display;
         (fmt, args)
     }
 }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -5,7 +5,7 @@ NOTE: This module is taken wholesale from <https://crates.io/crates/eyre>.
 */
 use std::{error::Error as StdError, vec};
 
-use ChainState::*;
+use ChainState::{Buffered, Linked};
 
 /// Iterator of a chain of source errors.
 ///
@@ -27,12 +27,13 @@ use ChainState::*;
 /// }
 /// ```
 #[derive(Clone)]
-#[allow(missing_debug_implementations)]
+#[expect(missing_debug_implementations)]
 pub struct Chain<'a> {
     state: crate::chain::ChainState<'a>,
 }
 
 #[derive(Clone)]
+#[expect(clippy::redundant_pub_crate, reason = "prevents accidental glob re-export")]
 pub(crate) enum ChainState<'a> {
     Linked { next: Option<&'a (dyn StdError + 'static)> },
     Buffered { rest: vec::IntoIter<&'a (dyn StdError + 'static)> },

--- a/src/diagnostic_chain.rs
+++ b/src/diagnostic_chain.rs
@@ -8,7 +8,7 @@ use crate::protocol::Diagnostic;
 
 /// Iterator of a chain of cause errors.
 #[derive(Clone, Default)]
-#[allow(missing_debug_implementations)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps this implementation type crate-private")]
 pub(crate) struct DiagnosticChain<'a> {
     state: Option<ErrorKind<'a>>,
 }
@@ -55,6 +55,7 @@ impl ExactSizeIterator for DiagnosticChain<'_> {
 }
 
 #[derive(Clone)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps this implementation type crate-private")]
 pub(crate) enum ErrorKind<'a> {
     Diagnostic(&'a dyn Diagnostic),
     StdError(&'a (dyn std::error::Error + 'static)),

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -8,22 +8,24 @@ use crate::{ptr::Ref, report_impl::ErrorImpl};
 
 impl ErrorImpl<()> {
     pub(crate) unsafe fn display(this: Ref<'_, Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: The caller guarantees that `this` points to a valid `ErrorImpl`.
         unsafe {
-            this.deref()
-                .handler
-                .as_ref()
-                .map(|handler| handler.display(Self::error(this), f))
-                .unwrap_or_else(|| core::fmt::Display::fmt(Self::diagnostic(this), f))
+            if let Some(handler) = this.deref().handler.as_ref() {
+                handler.display(Self::error(this), f)
+            } else {
+                core::fmt::Display::fmt(Self::diagnostic(this), f)
+            }
         }
     }
 
     pub(crate) unsafe fn debug(this: Ref<'_, Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: The caller guarantees that `this` points to a valid `ErrorImpl`.
         unsafe {
-            this.deref()
-                .handler
-                .as_ref()
-                .map(|handler| handler.debug(Self::diagnostic(this), f))
-                .unwrap_or_else(|| core::fmt::Debug::fmt(Self::diagnostic(this), f))
+            if let Some(handler) = this.deref().handler.as_ref() {
+                handler.debug(Self::diagnostic(this), f)
+            } else {
+                core::fmt::Debug::fmt(Self::diagnostic(this), f)
+            }
         }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -57,7 +57,7 @@ impl MietteHandlerOpts {
     /// Create a new `MietteHandlerOpts`.
     #[must_use]
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 
     /// If true, specify whether the graphical handler will make codes be
@@ -215,29 +215,12 @@ impl MietteHandlerOpts {
     pub fn build(self) -> MietteHandler {
         let graphical = self.is_graphical();
         let width = self.get_width();
-        if !graphical {
-            let mut handler = NarratableReportHandler::new();
-            if let Some(footer) = self.footer {
-                handler = handler.with_footer(footer);
-            }
-            if let Some(context_lines) = self.context_lines {
-                handler = handler.with_context_lines(context_lines);
-            }
-            if let Some(with_cause_chain) = self.with_cause_chain {
-                if with_cause_chain {
-                    handler = handler.with_cause_chain();
-                } else {
-                    handler = handler.without_cause_chain();
-                }
-            }
-            MietteHandler { inner: Box::new(handler) }
-        } else {
+        if graphical {
             let linkify = self.use_links();
             let characters = match self.unicode {
                 Some(true) => ThemeCharacters::unicode(),
-                Some(false) => ThemeCharacters::ascii(),
                 None if syscall::supports_unicode() => ThemeCharacters::unicode(),
-                None => ThemeCharacters::ascii(),
+                Some(false) | None => ThemeCharacters::ascii(),
             };
             let styles = if self.color == Some(false) {
                 ThemeStyles::none()
@@ -268,18 +251,34 @@ impl MietteHandlerOpts {
                 handler = handler.tab_width(w);
             }
             if let Some(b) = self.break_words {
-                handler = handler.with_break_words(b)
+                handler = handler.with_break_words(b);
             }
             if let Some(b) = self.wrap_lines {
-                handler = handler.with_wrap_lines(b)
+                handler = handler.with_wrap_lines(b);
             }
             if let Some(s) = self.word_separator {
-                handler = handler.with_word_separator(s)
+                handler = handler.with_word_separator(s);
             }
             if let Some(s) = self.word_splitter {
-                handler = handler.with_word_splitter(s)
+                handler = handler.with_word_splitter(s);
             }
 
+            MietteHandler { inner: Box::new(handler) }
+        } else {
+            let mut handler = NarratableReportHandler::new();
+            if let Some(footer) = self.footer {
+                handler = handler.with_footer(footer);
+            }
+            if let Some(context_lines) = self.context_lines {
+                handler = handler.with_context_lines(context_lines);
+            }
+            if let Some(with_cause_chain) = self.with_cause_chain {
+                if with_cause_chain {
+                    handler = handler.with_cause_chain();
+                } else {
+                    handler = handler.without_cause_chain();
+                }
+            }
             MietteHandler { inner: Box::new(handler) }
         }
     }
@@ -321,7 +320,7 @@ your own creation (or using one of its own defaults).
 See [`set_hook`](crate::set_hook) for more details on customizing your global
 printer.
 */
-#[allow(missing_debug_implementations)]
+#[expect(missing_debug_implementations)]
 pub struct MietteHandler {
     inner: Box<dyn ReportHandler + Send + Sync>,
 }
@@ -330,7 +329,7 @@ impl MietteHandler {
     /// Creates a new [`MietteHandler`] with default settings.
     #[must_use]
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
 }
 

--- a/src/handlers/debug.rs
+++ b/src/handlers/debug.rs
@@ -29,6 +29,11 @@ impl DebugReportHandler {
     /// Render a [`Diagnostic`]. This function is mostly internal and meant to
     /// be called by the toplevel [`ReportHandler`] handler, but is made public
     /// to make it easier (possible) to test in isolation from global state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the rendered report fails.
+    #[expect(clippy::unused_self, reason = "kept as a method for consistency with other handlers")]
     pub fn render_report(
         &self,
         f: &mut fmt::Formatter<'_>,

--- a/src/handlers/graphical/gutter.rs
+++ b/src/handlers/graphical/gutter.rs
@@ -153,11 +153,7 @@ impl GraphicalReportHandler {
                                 num_repeat
                                     // if we are rendering a multiline label, then leave a bit of space for the
                                     // rcross character
-                                    - if render_mode == LabelRenderMode::BlockFirst {
-                                        1
-                                    } else {
-                                        0
-                                    },
+                                    - usize::from(render_mode == LabelRenderMode::BlockFirst),
                             )
                             .style(hl.style)
                     )?;
@@ -169,13 +165,12 @@ impl GraphicalReportHandler {
                     gutter_cols += num_repeat + 1;
                 }
                 break;
-            } else {
-                write!(gutter, "{}", chars.vbar.style(hl.style))?;
-
-                // we may push many bytes for the ansi escape codes style adds,
-                // but we still only add a single character-width to the string in a terminal
-                gutter_cols += 1;
             }
+            write!(gutter, "{}", chars.vbar.style(hl.style))?;
+
+            // we may push many bytes for the ansi escape codes style adds,
+            // but we still only add a single character-width to the string in a terminal
+            gutter_cols += 1;
         }
 
         // now calculate how many spaces to add based on how many columns we just created.

--- a/src/handlers/graphical/handler.rs
+++ b/src/handlers/graphical/handler.rs
@@ -45,6 +45,7 @@ pub struct GraphicalReportHandler {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(clippy::redundant_pub_crate, reason = "prevents accidental glob re-export")]
 pub(crate) enum LinkStyle {
     Link,
     Text,

--- a/src/handlers/graphical/label.rs
+++ b/src/handlers/graphical/label.rs
@@ -26,7 +26,7 @@ struct Underline {
     left: usize,
     marker: char,
     right: usize,
-    underline: char,
+    line: char,
 }
 
 const CHUNK_CHARS: usize = 64;
@@ -71,15 +71,15 @@ impl fmt::Display for Underline {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Built-in themes repeat these characters frequently, so emit them in chunks.
         // Preserve the original character loop for custom themes.
-        let Some((underline_chunk, char_len)) = (match self.underline {
+        let Some((underline_chunk, char_len)) = (match self.line {
             '─' => Some((UNICODE_BARS, '─'.len_utf8())),
             '^' => Some((ASCII_CARETS, 1)),
             _ => None,
         }) else {
             write_repeated_char(f, ' ', self.padding)?;
-            write_repeated_char(f, self.underline, self.left)?;
+            write_repeated_char(f, self.line, self.left)?;
             f.write_char(self.marker)?;
-            return write_repeated_char(f, self.underline, self.right);
+            return write_repeated_char(f, self.line, self.right);
         };
 
         write_repeated_chunk(f, SPACES, 1, self.padding)?;
@@ -126,7 +126,7 @@ impl GraphicalReportHandler {
 
         let chars = &self.theme.characters;
         let mut vbar_offsets = Vec::with_capacity(single_liners.len());
-        for hl in single_liners {
+        for &hl in single_liners {
             let byte_start = hl.offset();
             let byte_end = hl.offset() + hl.len();
             let start = self.visual_offset(line, byte_start, true).max(highest);
@@ -136,7 +136,7 @@ impl GraphicalReportHandler {
                 self.visual_offset(line, byte_end, false).max(start + 1)
             };
 
-            let vbar_offset = (start + end) / 2;
+            let vbar_offset = usize::midpoint(start, end);
             let num_left = vbar_offset - start;
             let num_right = end - vbar_offset - 1;
             // Throws `Formatting argument out of range` when width is above u16::MAX.
@@ -156,7 +156,7 @@ impl GraphicalReportHandler {
                     left: num_left,
                     marker,
                     right: num_right,
-                    underline: chars.underline,
+                    line: chars.underline,
                 }
                 .style(hl.style)
             )?;
@@ -165,7 +165,7 @@ impl GraphicalReportHandler {
         }
         f.write_char('\n')?;
 
-        for hl in single_liners.iter().rev() {
+        for &hl in single_liners.iter().rev() {
             if let Some(label) = hl.label() {
                 let mut lines = label.split('\n');
                 let first = lines.next().expect("split always yields at least one item");
@@ -229,7 +229,7 @@ impl GraphicalReportHandler {
 
     // I know it's not good practice, but making this a function makes a lot of sense
     // and making a struct for this does not...
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     pub(super) fn write_label_text(
         &self,
         f: &mut impl fmt::Write,
@@ -238,8 +238,8 @@ impl GraphicalReportHandler {
         max_gutter: usize,
         all_highlights: &[FancySpan],
         chars: &ThemeCharacters,
-        vbar_offsets: &[(&&FancySpan, usize)],
-        hl: &&FancySpan,
+        vbar_offsets: &[(&FancySpan, usize)],
+        hl: &FancySpan,
         label: &str,
         render_mode: LabelRenderMode,
     ) -> fmt::Result {
@@ -256,14 +256,13 @@ impl GraphicalReportHandler {
             let padding = (*vbar_offset + 1).saturating_sub(curr_offset);
             write_padding(f, padding)?;
             curr_offset += padding;
-            if *offset_hl != hl {
-                write!(f, "{}", chars.vbar.style(offset_hl.style))?;
-                curr_offset += 1;
-            } else {
+            if *offset_hl == hl {
                 let line = LabelText { chars, label, style: hl.style, render_mode };
                 writeln!(f, "{}", line.style(hl.style))?;
                 break;
             }
+            write!(f, "{}", chars.vbar.style(offset_hl.style))?;
+            curr_offset += 1;
         }
         Ok(())
     }

--- a/src/handlers/graphical/line.rs
+++ b/src/handlers/graphical/line.rs
@@ -20,7 +20,7 @@ use crate::{MietteSpanContents, SpanContents};
 
 #[derive(Debug)]
 pub(super) struct Line<'a> {
-    pub(super) line_number: usize,
+    pub(super) number: usize,
     pub(super) offset: usize,
     pub(super) length: usize,
     pub(super) text: &'a str,
@@ -212,6 +212,7 @@ impl GraphicalReportHandler {
     /// [`render_snippets`](GraphicalReportHandler::render_snippets) so the span
     /// doesn't have to be re-read (each read is a scan of the source up to the
     /// span).
+    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
     pub(super) fn get_lines<'a>(&self, context_data: &MietteSpanContents<'a>) -> Vec<Line<'a>> {
         let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
@@ -230,7 +231,7 @@ impl GraphicalReportHandler {
                 if newline > start && bytes[newline - 1] == b'\r' { newline - 1 } else { newline };
             line += 1;
             lines.push(Line {
-                line_number: line,
+                number: line,
                 offset: base + start,
                 length: end - start,
                 text: &context[start..text_end],
@@ -244,7 +245,7 @@ impl GraphicalReportHandler {
                 line += 1;
             }
             lines.push(Line {
-                line_number: line,
+                number: line,
                 offset: base + start,
                 length: bytes.len() - start,
                 text: &context[start..],
@@ -256,6 +257,11 @@ impl GraphicalReportHandler {
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::cast_possible_truncation,
+        reason = "test fixtures are much smaller than u32::MAX"
+    )]
+
     use super::*;
     use crate::SourceCode;
 
@@ -287,7 +293,7 @@ mod tests {
             let actual = handler
                 .get_lines(&contents)
                 .iter()
-                .map(|line| (line.line_number, line.offset, line.length, line.text))
+                .map(|line| (line.number, line.offset, line.length, line.text))
                 .collect::<Vec<_>>();
             assert_eq!(actual, expected, "text={text:?}");
         }

--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -20,6 +20,10 @@ impl GraphicalReportHandler {
     /// be called by the toplevel [`ReportHandler`](crate::ReportHandler)
     /// handler, but is made public to make it easier (possible) to test in
     /// isolation from global state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the rendered report fails.
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
@@ -54,7 +58,7 @@ impl GraphicalReportHandler {
                 Some(code) => {
                     format!("{code} ")
                 }
-                _ => "".to_string(),
+                _ => String::new(),
             };
             let display_text = self.link_display_text.as_deref().unwrap_or("(link)");
             let link = format!(
@@ -67,7 +71,7 @@ impl GraphicalReportHandler {
             writeln!(f, "{header}")?;
             writeln!(f)?;
         } else if let Some(code) = diagnostic.code() {
-            write!(header, "{}", code.style(severity_style),)?;
+            write!(header, "{}", code.style(severity_style))?;
             if self.links == LinkStyle::Text && diagnostic.url().is_some() {
                 let url = diagnostic.url().unwrap(); // safe
                 write!(header, " ({})", url.style(self.theme.styles.link))?;
@@ -104,7 +108,7 @@ impl GraphicalReportHandler {
                 const END: &str = "\u{1b}]8;;\u{1b}\\";
                 let code = code.style(severity_style);
                 let title = diagnostic.style(severity_style);
-                format!("{CTL}{url}\u{1b}\\{code}{END}: {title}",)
+                format!("{CTL}{url}\u{1b}\\{code}{END}: {title}")
             }
             (_, _, Some(code)) if severity_style.is_plain() => format!("{code}: {diagnostic}"),
             (_, _, Some(code)) => {
@@ -154,7 +158,7 @@ impl GraphicalReportHandler {
                     Some(Severity::Error) | None => write!(f, "Error: ")?,
                     Some(Severity::Warning) => write!(f, "Warning: ")?,
                     Some(Severity::Advice) => write!(f, "Advice: ")?,
-                };
+                }
                 inner_renderer.render_header(f, rel)?;
                 inner_renderer.render_causes(f, rel)?;
                 let src = rel.source_code().or(parent_src);

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -28,10 +28,7 @@ impl GraphicalReportHandler {
         diagnostic: &dyn Diagnostic,
         opt_source: Option<&dyn SourceCode>,
     ) -> fmt::Result {
-        let source = match opt_source {
-            Some(source) => source,
-            None => return Ok(()),
-        };
+        let Some(source) = opt_source else { return Ok(()) };
         let mut labels = diagnostic.labels();
         if labels.is_empty() {
             return Ok(());
@@ -48,7 +45,7 @@ impl GraphicalReportHandler {
             .map(|bytes| SpanScanner::new(bytes, self.context_lines, self.context_lines));
         let source_name = source.name();
         let mut read = |span: &SourceSpan| match scanner.as_mut() {
-            Some(scanner) => scanner.read_span(span).map(|contents| match source_name {
+            Some(scanner) => scanner.read_span(*span).map(|contents| match source_name {
                 Some(name) => MietteSpanContents::new_named(
                     Cow::Borrowed(name),
                     contents.data(),
@@ -63,7 +60,7 @@ impl GraphicalReportHandler {
         };
 
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
-        for right in labels.iter() {
+        for right in &labels {
             let right_conts = read(right.inner()).map_err(|_| fmt::Error)?;
 
             if contexts.is_empty() {
@@ -94,7 +91,7 @@ impl GraphicalReportHandler {
             contexts.push((Cow::Borrowed(right), right_conts));
         }
         for (ctx, conts) in contexts {
-            self.render_context(f, &ctx, conts, &labels[..])?;
+            self.render_context(f, &ctx, &conts, &labels[..])?;
         }
 
         Ok(())
@@ -104,10 +101,10 @@ impl GraphicalReportHandler {
         &self,
         f: &mut impl fmt::Write,
         context: &LabeledSpan,
-        contents: MietteSpanContents<'_>,
+        contents: &MietteSpanContents<'_>,
         labels: &[LabeledSpan],
     ) -> fmt::Result {
-        let lines = self.get_lines(&contents);
+        let lines = self.get_lines(contents);
 
         // only consider labels from the context as primary label
         let ctx_labels = labels.iter().filter(|l| {
@@ -121,7 +118,7 @@ impl GraphicalReportHandler {
         // sorting is your friend
         let labels = labels
             .iter()
-            .zip(self.theme.styles.highlights.iter().cloned().cycle())
+            .zip(self.theme.styles.highlights.iter().copied().cycle())
             .map(|(label, st)| FancySpan::new(label.label(), *label.inner(), st))
             .collect::<Vec<_>>();
 
@@ -141,13 +138,7 @@ impl GraphicalReportHandler {
 
         // Oh and one more thing: We need to figure out how much room our line
         // numbers need!
-        let linum_width = lines[..]
-            .last()
-            .map(|line| line.line_number)
-            // It's possible for the source to be an empty string.
-            .unwrap_or(0)
-            .to_string()
-            .len();
+        let linum_width = lines[..].last().map_or(0, |line| line.number).to_string().len();
 
         // Header
         write!(
@@ -188,7 +179,7 @@ impl GraphicalReportHandler {
         // Now it's time for the fun part--actually rendering everything!
         for line in &lines {
             // Line number, appropriately padded.
-            self.write_linum(f, linum_width, line.line_number)?;
+            self.write_linum(f, linum_width, line.number)?;
 
             // Then, we need to print the gutter, along with any fly-bys We
             // have separate gutters depending on whether we're on the actual

--- a/src/handlers/graphical/span.rs
+++ b/src/handlers/graphical/span.rs
@@ -12,7 +12,7 @@ use crate::SourceSpan;
 ///
 /// A label can be a single trailing line, or a block that spans several output
 /// lines (the first line drawn differently from the rest).
-#[derive(PartialEq, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub(super) enum LabelRenderMode {
     /// we're rendering a single line label (or not rendering in any special way)
     SingleLine,

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -59,15 +59,19 @@ impl JSONReportHandler {
     /// Render a [`Diagnostic`]. This function is mostly internal and meant to
     /// be called by the toplevel [`ReportHandler`] handler, but is made public
     /// to make it easier (possible) to test in isolation from global state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the rendered report fails.
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
     ) -> fmt::Result {
-        self._render_report(f, diagnostic, None)
+        self.render_report_inner(f, diagnostic, None)
     }
 
-    fn _render_report(
+    fn render_report_inner(
         &self,
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
@@ -103,7 +107,7 @@ impl JSONReportHandler {
             write!(f, r#""causes": [],"#)?;
         }
         if let Some(url) = diagnostic.url() {
-            write!(f, r#""url": "{}","#, url)?;
+            write!(f, r#""url": "{url}","#)?;
         }
         if let Some(help) = diagnostic.help() {
             write!(f, r#""help": "{}","#, escape(&help))?;
@@ -159,13 +163,14 @@ impl JSONReportHandler {
                 } else {
                     add_comma = true;
                 }
-                self._render_report(f, related, src)?;
+                self.render_report_inner(f, related, src)?;
             }
             write!(f, "]")?;
         }
         write!(f, "}}")
     }
 
+    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
     fn render_snippets(
         &self,
         f: &mut impl fmt::Write,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -2,16 +2,11 @@
 Reporters included with `miette`.
 */
 
-#[allow(unreachable_pub)]
 pub use debug::*;
-#[allow(unreachable_pub)]
 #[cfg(feature = "fancy-base")]
 pub use graphical::*;
-#[allow(unreachable_pub)]
 pub use json::*;
-#[allow(unreachable_pub)]
 pub use narratable::*;
-#[allow(unreachable_pub)]
 #[cfg(feature = "fancy-base")]
 pub use theme::*;
 

--- a/src/handlers/narratable.rs
+++ b/src/handlers/narratable.rs
@@ -69,6 +69,10 @@ impl NarratableReportHandler {
     /// be called by the toplevel [`ReportHandler`] handler, but is
     /// made public to make it easier (possible) to test in isolation from
     /// global state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the rendered report fails.
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
@@ -88,6 +92,7 @@ impl NarratableReportHandler {
         Ok(())
     }
 
+    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
     fn render_header(&self, f: &mut impl fmt::Write, diagnostic: &dyn Diagnostic) -> fmt::Result {
         writeln!(f, "{diagnostic}")?;
         let severity = match diagnostic.severity() {
@@ -99,6 +104,7 @@ impl NarratableReportHandler {
         Ok(())
     }
 
+    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
     fn render_causes(&self, f: &mut impl fmt::Write, diagnostic: &dyn Diagnostic) -> fmt::Result {
         if let Some(cause_iter) = diagnostic
             .diagnostic_source()
@@ -113,6 +119,7 @@ impl NarratableReportHandler {
         Ok(())
     }
 
+    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
     fn render_footer(&self, f: &mut impl fmt::Write, diagnostic: &dyn Diagnostic) -> fmt::Result {
         if let Some(help) = diagnostic.help() {
             writeln!(f, "diagnostic help: {help}")?;
@@ -140,7 +147,7 @@ impl NarratableReportHandler {
                     Some(Severity::Error) | None => write!(f, "Error: ")?,
                     Some(Severity::Warning) => write!(f, "Warning: ")?,
                     Some(Severity::Advice) => write!(f, "Advice: ")?,
-                };
+                }
                 self.render_header(f, rel)?;
                 writeln!(f)?;
                 self.render_causes(f, rel)?;
@@ -166,7 +173,7 @@ impl NarratableReportHandler {
                 if !labels.is_empty() {
                     let mut contexts: Vec<(LabeledSpan, MietteSpanContents<'_>)> =
                         Vec::with_capacity(labels.len());
-                    for right in labels.iter() {
+                    for right in &labels {
                         let right_conts = source
                             .read_span(right.inner(), self.context_lines, self.context_lines)
                             .map_err(|_| fmt::Error)?;
@@ -207,7 +214,7 @@ impl NarratableReportHandler {
                         contexts.push((right.clone(), right_conts));
                     }
                     for (_, conts) in contexts {
-                        self.render_context(f, conts, &labels[..])?;
+                        self.render_context(f, &conts, &labels[..])?;
                     }
                 }
             }
@@ -218,10 +225,10 @@ impl NarratableReportHandler {
     fn render_context(
         &self,
         f: &mut impl fmt::Write,
-        contents: MietteSpanContents<'_>,
+        contents: &MietteSpanContents<'_>,
         labels: &[LabeledSpan],
     ) -> fmt::Result {
-        let lines = self.get_lines(&contents);
+        let lines = self.get_lines(contents);
         write!(f, "Begin snippet")?;
         if let Some(filename) = contents.name() {
             write!(f, " for {filename}")?;
@@ -229,34 +236,30 @@ impl NarratableReportHandler {
         writeln!(f, " starting at line {}, column {}", contents.line() + 1, contents.column() + 1)?;
         writeln!(f)?;
         for line in &lines {
-            writeln!(f, "snippet line {}: {}", line.line_number, line.text)?;
+            writeln!(f, "snippet line {}: {}", line.number, line.text)?;
             let relevant =
-                labels.iter().filter_map(|l| line.span_attach(l.inner()).map(|a| (a, l)));
+                labels.iter().filter_map(|l| line.span_attach(*l.inner()).map(|a| (a, l)));
             for (attach, label) in relevant {
                 match attach {
                     SpanAttach::Contained { col_start, col_end } if col_start == col_end => {
-                        write!(f, "    label at line {}, column {}", line.line_number, col_start,)?;
+                        write!(f, "    label at line {}, column {}", line.number, col_start)?;
                     }
                     SpanAttach::Contained { col_start, col_end } => {
                         write!(
                             f,
                             "    label at line {}, columns {} to {}",
-                            line.line_number, col_start, col_end,
+                            line.number, col_start, col_end,
                         )?;
                     }
                     SpanAttach::Starts { col_start } => {
                         write!(
                             f,
                             "    label starting at line {}, column {}",
-                            line.line_number, col_start,
+                            line.number, col_start,
                         )?;
                     }
                     SpanAttach::Ends { col_end } => {
-                        write!(
-                            f,
-                            "    label ending at line {}, column {}",
-                            line.line_number, col_end,
-                        )?;
+                        write!(f, "    label ending at line {}, column {}", line.number, col_end)?;
                     }
                 }
                 if let Some(label) = label.label() {
@@ -272,6 +275,7 @@ impl NarratableReportHandler {
     /// produced by the `read_span` call in [`Self::render_snippets`] so the
     /// span doesn't have to be re-read (each read is a scan of the source up
     /// to the span).
+    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
     fn get_lines<'a>(&self, context_data: &MietteSpanContents<'a>) -> Vec<Line<'a>> {
         let context = from_utf8(context_data.data()).expect("Bad utf8 detected");
         let mut line = context_data.line();
@@ -317,7 +321,7 @@ impl NarratableReportHandler {
             if column == 0 || iter.peek().is_none() {
                 let text_start = line_offset - base;
                 lines.push(Line {
-                    line_number: line,
+                    number: line,
                     offset: line_offset,
                     text: &context[text_start..text_start + line_len],
                     at_end_of_file,
@@ -345,7 +349,7 @@ Support types
 */
 
 struct Line<'a> {
-    line_number: usize,
+    number: usize,
     offset: usize,
     text: &'a str,
     at_end_of_file: bool,
@@ -360,16 +364,19 @@ enum SpanAttach {
 /// Returns column at offset, and nearest boundary if offset is in the middle of
 /// the character
 fn safe_get_column(text: &str, offset: usize, start: bool) -> usize {
-    let mut column = text.get(0..offset).map(UnicodeWidthStr::width).unwrap_or_else(|| {
-        let mut column = 0;
-        for (idx, c) in text.char_indices() {
-            if offset <= idx {
-                break;
+    let mut column = text.get(0..offset).map_or_else(
+        || {
+            let mut column = 0;
+            for (idx, c) in text.char_indices() {
+                if offset <= idx {
+                    break;
+                }
+                column += c.width().unwrap_or(0);
             }
-            column += c.width().unwrap_or(0);
-        }
-        column
-    });
+            column
+        },
+        UnicodeWidthStr::width,
+    );
     if start {
         // Offset are zero-based, so plus one
         column += 1;
@@ -379,7 +386,7 @@ fn safe_get_column(text: &str, offset: usize, start: bool) -> usize {
 }
 
 impl Line<'_> {
-    fn span_attach(&self, span: &SourceSpan) -> Option<SpanAttach> {
+    fn span_attach(&self, span: SourceSpan) -> Option<SpanAttach> {
         let span_offset = span.offset() as usize;
         let span_end = span_offset + span.len() as usize;
         let line_end = self.offset + self.text.len();

--- a/src/handlers/theme.rs
+++ b/src/handlers/theme.rs
@@ -184,7 +184,7 @@ impl ThemeStyles {
 
 /// Characters to be used when drawing when using
 /// [`GraphicalReportHandler`](crate::GraphicalReportHandler).
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ThemeCharacters {
     pub hbar: char,

--- a/src/into_diagnostic.rs
+++ b/src/into_diagnostic.rs
@@ -26,6 +26,10 @@ inaccessible. If you have a type implementing [`Diagnostic`] consider simply ret
 pub trait IntoDiagnostic<T, E> {
     /// Converts [`Result`] types that return regular [`std::error::Error`]s
     /// into a [`Result`] that returns a [`Diagnostic`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the source error wrapped in a [`Report`].
     fn into_diagnostic(self) -> Result<T, Report>;
 }
 

--- a/src/kind.rs
+++ b/src/kind.rs
@@ -1,8 +1,10 @@
-#![allow(
+#![expect(
     missing_debug_implementations,
     missing_docs,
     clippy::new_ret_no_self,
-    clippy::wrong_self_convention
+    clippy::unused_self,
+    clippy::wrong_self_convention,
+    reason = "receiver types implement autoref specialization dispatch"
 )]
 //! Autoref-specialization dispatch for `miette!(expr)`: picks up the argument's
 //! [`std::error::Error`] impl when it has one, otherwise falls back to

--- a/src/macro_helpers.rs
+++ b/src/macro_helpers.rs
@@ -31,7 +31,11 @@ where
     T: IsOption,
 {
     #[doc(hidden)]
-    #[allow(clippy::wrong_self_convention)]
+    #[expect(
+        clippy::unused_self,
+        clippy::wrong_self_convention,
+        reason = "the receiver enables autoref specialization in generated code"
+    )]
     pub fn to_option(self, value: &T) -> &T {
         value
     }
@@ -45,6 +49,10 @@ impl<T> ToOption for &OptionalWrapper<T> {
 
 #[doc(hidden)]
 #[derive(Debug)]
+#[expect(
+    clippy::empty_structs_with_brackets,
+    reason = "retained for public construction syntax compatibility"
+)]
 pub struct ToLabelSpanWrapper {}
 pub trait ToLabeledSpan<T> {
     #[doc(hidden)]

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -1,3 +1,4 @@
+use std::io::Write as _;
 use std::{env, fmt::Write, mem::size_of, panic::set_hook};
 
 use backtrace::Backtrace;
@@ -14,13 +15,13 @@ pub fn set_panic_hook() {
             message = msg.to_string();
         }
         if let Some(msg) = payload.downcast_ref::<String>() {
-            message = msg.clone();
+            message.clone_from(msg);
         }
         if let Some(loc) = info.location() {
             let _ = write!(message, "\n\tat {}:{}:{}", loc.file(), loc.line(), loc.column());
         }
         let report: Report = Panic(message).into();
-        eprintln!("Error: {report:?}");
+        let _ = writeln!(std::io::stderr().lock(), "Error: {report:?}");
     }));
 }
 
@@ -80,6 +81,6 @@ impl Panic {
                 return backtrace;
             }
         }
-        "".into()
+        String::new()
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -336,6 +336,14 @@ gigabytes or larger in size.
 pub trait SourceCode: Send + Sync {
     /// Read the bytes for a specific span from this `SourceCode`, keeping a
     /// certain number of lines before and after the span as context.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the requested span cannot be read.
+    #[expect(
+        clippy::trivially_copy_pass_by_ref,
+        reason = "retained for public trait compatibility"
+    )]
     fn read_span<'a>(
         &'a self,
         span: &SourceSpan,
@@ -641,12 +649,14 @@ impl SourceSpan {
 
     /// The absolute offset, in bytes, from the beginning of a [`SourceCode`].
     #[must_use]
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "retained for public API compatibility")]
     pub const fn offset(&self) -> ByteOffset {
         self.offset.offset()
     }
 
     /// Total length of the [`SourceSpan`], in bytes.
     #[must_use]
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "retained for public API compatibility")]
     pub const fn len(&self) -> u32 {
         self.length
     }
@@ -654,6 +664,7 @@ impl SourceSpan {
     /// Whether this [`SourceSpan`] has a length of zero. It may still be useful
     /// to point to a specific point.
     #[must_use]
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "retained for public API compatibility")]
     pub const fn is_empty(&self) -> bool {
         self.length == 0
     }
@@ -675,7 +686,8 @@ impl From<Range<ByteOffset>> for SourceSpan {
     fn from(range: Range<ByteOffset>) -> Self {
         // `Range::len` returns `0` for empty/reversed ranges, matching the
         // previous behavior and avoiding underflow.
-        Self { offset: range.start.into(), length: range.len() as u32 }
+        let length = u32::try_from(range.len()).unwrap_or(u32::MAX);
+        Self { offset: range.start.into(), length }
     }
 }
 
@@ -706,6 +718,7 @@ pub struct SourceOffset(ByteOffset);
 impl SourceOffset {
     /// Actual byte offset.
     #[must_use]
+    #[expect(clippy::trivially_copy_pass_by_ref, reason = "retained for public API compatibility")]
     pub const fn offset(&self) -> ByteOffset {
         self.0
     }
@@ -733,7 +746,7 @@ impl SourceOffset {
             offset += char.len_utf8();
         }
 
-        SourceOffset(offset as u32)
+        SourceOffset(u32::try_from(offset).unwrap_or(u32::MAX))
     }
 
     /// Returns an offset for the _file_ location of wherever this function is
@@ -747,6 +760,10 @@ impl SourceOffset {
     /// file was compiled from is actually available at that location. If
     /// you're shipping binaries for your application, you'll want to ignore
     /// the Err case or otherwise report it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the caller's source file cannot be read.
     #[track_caller]
     pub fn from_current_location() -> Result<(String, Self), MietteError> {
         let loc = Location::caller();

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -6,6 +6,7 @@ use std::{marker::PhantomData, ptr::NonNull};
 
 #[repr(transparent)]
 /// A raw pointer that owns its pointee
+#[expect(clippy::redundant_pub_crate, reason = "keeps pointer internals crate-private")]
 pub(crate) struct Own<T>
 where
     T: ?Sized,
@@ -13,8 +14,10 @@ where
     pub(crate) ptr: NonNull<T>,
 }
 
-unsafe impl<T> Send for Own<T> where T: ?Sized {}
-unsafe impl<T> Sync for Own<T> where T: ?Sized {}
+// SAFETY: `Own` has exclusive ownership and only transfers a `Send` pointee.
+unsafe impl<T> Send for Own<T> where T: ?Sized + Send {}
+// SAFETY: Shared access through `Own` is safe only when the pointee is `Sync`.
+unsafe impl<T> Sync for Own<T> where T: ?Sized + Sync {}
 
 impl<T> Copy for Own<T> where T: ?Sized {}
 
@@ -32,7 +35,7 @@ where
     T: ?Sized,
 {
     pub(crate) fn new(ptr: Box<T>) -> Self {
-        Own { ptr: unsafe { NonNull::new_unchecked(Box::into_raw(ptr)) } }
+        Own { ptr: NonNull::from(Box::leak(ptr)) }
     }
 
     pub(crate) fn cast<U: CastTo>(self) -> Own<U::Target> {
@@ -40,6 +43,8 @@ where
     }
 
     pub(crate) unsafe fn boxed(self) -> Box<T> {
+        // SAFETY: `Own` was constructed from a `Box` and still uniquely owns
+        // the same allocation.
         unsafe { Box::from_raw(self.ptr.as_ptr()) }
     }
 
@@ -52,9 +57,9 @@ where
     }
 }
 
-#[allow(explicit_outlives_requirements)]
 #[repr(transparent)]
 /// A raw pointer that represents a shared borrow of its pointee
+#[expect(clippy::redundant_pub_crate, reason = "keeps pointer internals crate-private")]
 pub(crate) struct Ref<'a, T>
 where
     T: ?Sized,
@@ -95,17 +100,18 @@ where
     }
 
     pub(crate) const fn as_ptr(self) -> *const T {
-        self.ptr.as_ptr() as *const T
+        self.ptr.as_ptr().cast_const()
     }
 
     pub(crate) unsafe fn deref(self) -> &'a T {
+        // SAFETY: The caller guarantees the pointer remains valid for `'a`.
         unsafe { &*self.ptr.as_ptr() }
     }
 }
 
-#[allow(explicit_outlives_requirements)]
 #[repr(transparent)]
 /// A raw pointer that represents a unique borrow of its pointee
+#[expect(clippy::redundant_pub_crate, reason = "keeps pointer internals crate-private")]
 pub(crate) struct Mut<'a, T>
 where
     T: ?Sized,
@@ -142,16 +148,21 @@ where
     }
 
     pub(crate) unsafe fn deref_mut(self) -> &'a mut T {
+        // SAFETY: The caller guarantees exclusive access to a valid pointee
+        // for `'a`.
         unsafe { &mut *self.ptr.as_ptr() }
     }
 }
 
 impl<T> Mut<'_, T> {
     pub(crate) unsafe fn read(self) -> T {
+        // SAFETY: The caller guarantees the pointer is valid for reads and
+        // transfers ownership of the pointee.
         unsafe { self.ptr.as_ptr().read() }
     }
 }
 
+#[expect(clippy::redundant_pub_crate, reason = "keeps pointer internals crate-private")]
 pub(crate) trait CastTo {
     type Target;
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -12,7 +12,6 @@
 use std::{error::Error as StdError, sync::OnceLock};
 
 /// Compatibility re-export of `Report` for interop with `anyhow`
-#[allow(unreachable_pub)]
 pub use Report as Error;
 
 #[cfg(not(feature = "fancy-base"))]
@@ -32,7 +31,10 @@ pub struct Report {
     pub(crate) inner: Own<ErrorImpl<()>>,
 }
 
+// SAFETY: `Report` only exposes the erased value when its concrete type is
+// `Send + Sync`, and `Own` has exclusive ownership of the allocation.
 unsafe impl Sync for Report {}
+// SAFETY: See the `Sync` implementation above.
 unsafe impl Send for Report {}
 
 /// `ErrorHook`
@@ -57,12 +59,17 @@ impl Diagnostic for InstallError {}
 
 /**
 Set the error hook.
+
+# Errors
+
+Returns [`InstallError`] when a hook was already installed.
 */
 pub fn set_hook(hook: ErrorHook) -> Result<(), InstallError> {
     HOOK.set(hook).map_err(|_| InstallError)
 }
 
 #[track_caller]
+#[expect(clippy::redundant_pub_crate, reason = "keeps hook plumbing crate-private")]
 pub(crate) fn capture_handler(error: &(dyn Diagnostic + 'static)) -> Box<dyn ReportHandler> {
     let hook = HOOK.get_or_init(|| Box::new(get_default_printer)).as_ref();
     hook(error)
@@ -91,7 +98,8 @@ impl dyn ReportHandler {
     /// `downcast_ref`
     pub fn downcast_ref<T: ReportHandler>(&self) -> Option<&T> {
         if self.is::<T>() {
-            unsafe { Some(&*(self as *const dyn ReportHandler as *const T)) }
+            // SAFETY: `is::<T>()` proves the trait object's concrete type is `T`.
+            unsafe { Some(&*std::ptr::from_ref::<dyn ReportHandler>(self).cast::<T>()) }
         } else {
             None
         }
@@ -100,7 +108,9 @@ impl dyn ReportHandler {
     /// `downcast_mut`
     pub fn downcast_mut<T: ReportHandler>(&mut self) -> Option<&mut T> {
         if self.is::<T>() {
-            unsafe { Some(&mut *(self as *mut dyn ReportHandler as *mut T)) }
+            // SAFETY: `is::<T>()` proves the trait object's concrete type is `T`,
+            // and `&mut self` guarantees exclusive access.
+            unsafe { Some(&mut *std::ptr::from_mut::<dyn ReportHandler>(self).cast::<T>()) }
         } else {
             None
         }
@@ -139,9 +149,17 @@ pub trait ReportHandler: core::any::Any + Send + Sync {
     ///     }
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the report fails.
     fn debug(&self, error: &dyn Diagnostic, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result;
 
     /// Override for the `Display` format
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the report fails.
     fn display(
         &self,
         error: &(dyn StdError + 'static),
@@ -159,7 +177,7 @@ pub trait ReportHandler: core::any::Any + Send + Sync {
     }
 
     /// Store the location of the caller who constructed this error report
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn track_caller(&mut self, location: &'static std::panic::Location<'static>) {}
 }
 

--- a/src/report_impl.rs
+++ b/src/report_impl.rs
@@ -106,18 +106,18 @@ impl Report {
         E: Diagnostic + Send + Sync + 'static,
     {
         let vtable = &ErrorVTable {
-            object_drop: object_drop::<E>,
-            object_ref: object_ref::<E>,
-            object_ref_stderr: object_ref_stderr::<E>,
-            object_boxed: object_boxed::<E>,
-            object_boxed_stderr: object_boxed_stderr::<E>,
-            object_downcast: object_downcast::<E>,
-            object_drop_rest: object_drop_front::<E>,
+            drop: object_drop::<E>,
+            as_diagnostic: object_ref::<E>,
+            as_error: object_ref_stderr::<E>,
+            into_diagnostic: object_boxed::<E>,
+            into_error: object_boxed_stderr::<E>,
+            downcast: object_downcast::<E>,
+            drop_rest: object_drop_front::<E>,
         };
 
-        // Safety: passing vtable that operates on the right type E.
         let handler = Some(crate::report::capture_handler(&error));
 
+        // SAFETY: Every vtable entry above is monomorphized for `E`.
         unsafe { Report::construct(error, vtable, handler) }
     }
 
@@ -129,19 +129,19 @@ impl Report {
         use crate::wrapper::MessageError;
         let error: MessageError<M> = MessageError(message);
         let vtable = &ErrorVTable {
-            object_drop: object_drop::<MessageError<M>>,
-            object_ref: object_ref::<MessageError<M>>,
-            object_ref_stderr: object_ref_stderr::<MessageError<M>>,
-            object_boxed: object_boxed::<MessageError<M>>,
-            object_boxed_stderr: object_boxed_stderr::<MessageError<M>>,
-            object_downcast: object_downcast::<M>,
-            object_drop_rest: object_drop_front::<M>,
+            drop: object_drop::<MessageError<M>>,
+            as_diagnostic: object_ref::<MessageError<M>>,
+            as_error: object_ref_stderr::<MessageError<M>>,
+            into_diagnostic: object_boxed::<MessageError<M>>,
+            into_error: object_boxed_stderr::<MessageError<M>>,
+            downcast: object_downcast::<M>,
+            drop_rest: object_drop_front::<M>,
         };
 
-        // Safety: MessageError is repr(transparent) so it is okay for the
-        // vtable to allow casting the MessageError<M> to M.
         let handler = Some(crate::report::capture_handler(&error));
 
+        // SAFETY: `MessageError` is transparent, and every vtable entry is
+        // monomorphized for either `MessageError<M>` or its inner `M`.
         unsafe { Report::construct(error, vtable, handler) }
     }
 
@@ -152,16 +152,16 @@ impl Report {
         let handler = Some(crate::report::capture_handler(&error));
 
         let vtable = &ErrorVTable {
-            object_drop: object_drop::<BoxedError>,
-            object_ref: object_ref::<BoxedError>,
-            object_ref_stderr: object_ref_stderr::<BoxedError>,
-            object_boxed: object_boxed::<BoxedError>,
-            object_boxed_stderr: object_boxed_stderr::<BoxedError>,
-            object_downcast: object_downcast::<Box<dyn Diagnostic + Send + Sync>>,
-            object_drop_rest: object_drop_front::<Box<dyn Diagnostic + Send + Sync>>,
+            drop: object_drop::<BoxedError>,
+            as_diagnostic: object_ref::<BoxedError>,
+            as_error: object_ref_stderr::<BoxedError>,
+            into_diagnostic: object_boxed::<BoxedError>,
+            into_error: object_boxed_stderr::<BoxedError>,
+            downcast: object_downcast::<Box<dyn Diagnostic + Send + Sync>>,
+            drop_rest: object_drop_front::<Box<dyn Diagnostic + Send + Sync>>,
         };
 
-        // Safety: BoxedError is repr(transparent) so it is okay for the vtable
+        // SAFETY: BoxedError is repr(transparent) so it is okay for the vtable
         // to allow casting to Box<dyn StdError + Send + Sync>.
         unsafe { Report::construct(error, vtable, handler) }
     }
@@ -179,7 +179,7 @@ impl Report {
     where
         E: Diagnostic + Send + Sync + 'static,
     {
-        let inner = Box::new(ErrorImpl { vtable, handler, _object: error });
+        let inner = Box::new(ErrorImpl { vtable, handler, object: error });
         // Erase the concrete type of E from the compile-time type system. This
         // is equivalent to the safe unsize coercion from Box<ErrorImpl<E>> to
         // Box<ErrorImpl<dyn StdError + Send + Sync + 'static>> except that the
@@ -213,6 +213,8 @@ impl Report {
     /// ```
     #[must_use]
     pub fn chain(&self) -> Chain<'_> {
+        // SAFETY: `self.inner` points to an `ErrorImpl` paired with its original
+        // vtable for the lifetime of `self`.
         unsafe { ErrorImpl::chain(self.inner.by_ref()) }
     }
 
@@ -221,6 +223,11 @@ impl Report {
     ///
     /// The root cause is the last error in the iterator produced by
     /// [`chain()`](Report::chain).
+    ///
+    /// # Panics
+    ///
+    /// This would panic only if the report's cause chain were empty, which a
+    /// valid [`Report`] never permits.
     #[must_use]
     pub fn root_cause(&self) -> &(dyn StdError + 'static) {
         self.chain().next_back().unwrap()
@@ -243,16 +250,22 @@ impl Report {
     }
 
     /// Attempt to downcast the error object to a concrete type.
+    ///
+    /// # Errors
+    ///
+    /// Returns the original report when its stored value is not an `E`.
     pub fn downcast<E>(self) -> Result<E, Self>
     where
         E: Display + Debug + Send + Sync + 'static,
     {
         let target = TypeId::of::<E>();
         let inner = self.inner.by_mut();
+        // SAFETY: The vtable belongs to this allocation. Its downcast entry
+        // returns an `E` pointer only after a matching `TypeId`.
         unsafe {
             // Use vtable to find NonNull<()> which points to a value of type E
             // somewhere inside the data structure.
-            let addr = match (vtable(inner.ptr).object_downcast)(inner.by_ref(), target) {
+            let addr = match (vtable(inner.ptr).downcast)(inner.by_ref(), target) {
                 Some(addr) => addr.by_mut().extend(),
                 None => return Err(self),
             };
@@ -265,7 +278,7 @@ impl Report {
             let error = addr.cast::<E>().read();
 
             // Drop rest of the data structure outside of E.
-            (vtable(outer.inner.ptr).object_drop_rest)(outer.inner, target);
+            (vtable(outer.inner.ptr).drop_rest)(outer.inner, target);
 
             Ok(error)
         }
@@ -313,10 +326,12 @@ impl Report {
         E: Display + Debug + Send + Sync + 'static,
     {
         let target = TypeId::of::<E>();
+        // SAFETY: The vtable belongs to this allocation and validates `target`
+        // before returning the field pointer.
         unsafe {
             // Use vtable to find NonNull<()> which points to a value of type E
             // somewhere inside the data structure.
-            let addr = (vtable(self.inner.ptr).object_downcast)(self.inner.by_ref(), target)?;
+            let addr = (vtable(self.inner.ptr).downcast)(self.inner.by_ref(), target)?;
             Some(addr.cast::<E>().deref())
         }
     }
@@ -327,23 +342,33 @@ impl Report {
         E: Display + Debug + Send + Sync + 'static,
     {
         let target = TypeId::of::<E>();
+        // SAFETY: As above, with exclusive access guaranteed by `&mut self`.
         unsafe {
             // Use vtable to find NonNull<()> which points to a value of type E
             // somewhere inside the data structure.
-            let addr =
-                (vtable(self.inner.ptr).object_downcast)(self.inner.by_ref(), target)?.by_mut();
+            let addr = (vtable(self.inner.ptr).downcast)(self.inner.by_ref(), target)?.by_mut();
             Some(addr.cast::<E>().deref_mut())
         }
     }
 
     /// Get a reference to the Handler for this Report.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the report's internal handler invariant is violated.
     #[must_use]
     pub fn handler(&self) -> &dyn ReportHandler {
+        // SAFETY: `inner` is a live allocation owned by `self`.
         unsafe { self.inner.by_ref().deref().handler.as_ref().unwrap().as_ref() }
     }
 
     /// Get a mutable reference to the Handler for this Report.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the report's internal handler invariant is violated.
     pub fn handler_mut(&mut self) -> &mut dyn ReportHandler {
+        // SAFETY: `&mut self` guarantees exclusive access to the live allocation.
         unsafe { self.inner.by_mut().deref_mut().handler.as_mut().unwrap().as_mut() }
     }
 
@@ -368,54 +393,59 @@ impl Deref for Report {
     type Target = dyn Diagnostic + Send + Sync + 'static;
 
     fn deref(&self) -> &Self::Target {
+        // SAFETY: `inner` and its vtable remain valid for the lifetime of `self`.
         unsafe { ErrorImpl::diagnostic(self.inner.by_ref()) }
     }
 }
 
 impl DerefMut for Report {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: `&mut self` guarantees exclusive access to the erased value.
         unsafe { ErrorImpl::diagnostic_mut(self.inner.by_mut()) }
     }
 }
 
 impl Display for Report {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: `inner` and its vtable remain valid while formatting.
         unsafe { ErrorImpl::display(self.inner.by_ref(), formatter) }
     }
 }
 
 impl Debug for Report {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: `inner` and its vtable remain valid while formatting.
         unsafe { ErrorImpl::debug(self.inner.by_ref(), formatter) }
     }
 }
 
 impl Drop for Report {
     fn drop(&mut self) {
+        // SAFETY: The allocation is still owned here, and its matching vtable
+        // provides the correct concrete drop implementation.
         unsafe {
             // Invoke the vtable's drop behavior.
-            (vtable(self.inner.ptr).object_drop)(self.inner);
+            (vtable(self.inner.ptr).drop)(self.inner);
         }
     }
 }
 
 struct ErrorVTable {
-    object_drop: unsafe fn(Own<ErasedErrorImpl>),
-    object_ref:
+    drop: unsafe fn(Own<ErasedErrorImpl>),
+    as_diagnostic:
         unsafe fn(Ref<'_, ErasedErrorImpl>) -> Ref<'_, dyn Diagnostic + Send + Sync + 'static>,
-    object_ref_stderr:
-        unsafe fn(Ref<'_, ErasedErrorImpl>) -> Ref<'_, dyn StdError + Send + Sync + 'static>,
-    #[allow(clippy::type_complexity)]
-    object_boxed: unsafe fn(Own<ErasedErrorImpl>) -> Box<dyn Diagnostic + Send + Sync + 'static>,
-    #[allow(clippy::type_complexity)]
-    object_boxed_stderr:
-        unsafe fn(Own<ErasedErrorImpl>) -> Box<dyn StdError + Send + Sync + 'static>,
-    object_downcast: unsafe fn(Ref<'_, ErasedErrorImpl>, TypeId) -> Option<Ref<'_, ()>>,
-    object_drop_rest: unsafe fn(Own<ErasedErrorImpl>, TypeId),
+    as_error: unsafe fn(Ref<'_, ErasedErrorImpl>) -> Ref<'_, dyn StdError + Send + Sync + 'static>,
+    into_diagnostic: unsafe fn(Own<ErasedErrorImpl>) -> Box<dyn Diagnostic + Send + Sync + 'static>,
+    into_error: unsafe fn(Own<ErasedErrorImpl>) -> Box<dyn StdError + Send + Sync + 'static>,
+    downcast: unsafe fn(Ref<'_, ErasedErrorImpl>, TypeId) -> Option<Ref<'_, ()>>,
+    drop_rest: unsafe fn(Own<ErasedErrorImpl>, TypeId),
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must point to an `ErrorImpl<E>` allocation.
 unsafe fn object_drop<E>(e: Own<ErasedErrorImpl>) {
+    // SAFETY: Required by this function's contract.
     unsafe {
         // Cast back to ErrorImpl<E> so that the allocator receives the correct
         // Layout to deallocate the Box's memory.
@@ -424,8 +454,13 @@ unsafe fn object_drop<E>(e: Own<ErasedErrorImpl>) {
     }
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must point to an `ErrorImpl<E>` allocation, and `target` must describe
+/// the value already moved out by the caller.
 unsafe fn object_drop_front<E>(e: Own<ErasedErrorImpl>, target: TypeId) {
+    // SAFETY: Required by this function's contract; `ManuallyDrop<E>` prevents
+    // a second drop of the extracted value.
     unsafe {
         // Drop the fields of ErrorImpl other than E as well as the Box allocation,
         // without dropping E itself. This is used by downcast after doing a
@@ -436,65 +471,83 @@ unsafe fn object_drop_front<E>(e: Own<ErasedErrorImpl>, target: TypeId) {
     }
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must point to an `ErrorImpl<E>`.
 unsafe fn object_ref<E>(
     e: Ref<'_, ErasedErrorImpl>,
 ) -> Ref<'_, dyn Diagnostic + Send + Sync + 'static>
 where
     E: Diagnostic + Send + Sync + 'static,
 {
+    // SAFETY: Required by this function's contract. `addr_of!` yields the
+    // non-null address of the live `object` field.
     unsafe {
-        // Attach E's native StdError vtable onto a pointer to self._object.
+        // Attach E's native StdError vtable onto a pointer to `self.object`.
         let unerased = e.cast::<ErrorImpl<E>>();
 
-        Ref::from_raw(NonNull::new_unchecked(ptr::addr_of!((*unerased.as_ptr())._object) as *mut E))
+        Ref::from_raw(NonNull::new_unchecked(ptr::addr_of!((*unerased.as_ptr()).object).cast_mut()))
     }
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must point to an `ErrorImpl<E>`.
 unsafe fn object_ref_stderr<E>(
     e: Ref<'_, ErasedErrorImpl>,
 ) -> Ref<'_, dyn StdError + Send + Sync + 'static>
 where
     E: StdError + Send + Sync + 'static,
 {
+    // SAFETY: Required by this function's contract. `addr_of!` yields the
+    // non-null address of the live `object` field.
     unsafe {
-        // Attach E's native StdError vtable onto a pointer to self._object.
+        // Attach E's native StdError vtable onto a pointer to `self.object`.
         let unerased = e.cast::<ErrorImpl<E>>();
 
-        Ref::from_raw(NonNull::new_unchecked(ptr::addr_of!((*unerased.as_ptr())._object) as *mut E))
+        Ref::from_raw(NonNull::new_unchecked(ptr::addr_of!((*unerased.as_ptr()).object).cast_mut()))
     }
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must own an `ErrorImpl<E>` allocation.
 unsafe fn object_boxed<E>(e: Own<ErasedErrorImpl>) -> Box<dyn Diagnostic + Send + Sync + 'static>
 where
     E: Diagnostic + Send + Sync + 'static,
 {
+    // SAFETY: Required by this function's contract.
     unsafe {
         // Attach ErrorImpl<E>'s native StdError vtable. The StdError impl is below.
         e.cast::<ErrorImpl<E>>().boxed()
     }
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must own an `ErrorImpl<E>` allocation.
 unsafe fn object_boxed_stderr<E>(
     e: Own<ErasedErrorImpl>,
 ) -> Box<dyn StdError + Send + Sync + 'static>
 where
     E: StdError + Send + Sync + 'static,
 {
+    // SAFETY: Required by this function's contract.
     unsafe {
         // Attach ErrorImpl<E>'s native StdError vtable. The StdError impl is below.
         e.cast::<ErrorImpl<E>>().boxed()
     }
 }
 
-// Safety: requires layout of *e to match ErrorImpl<E>.
+/// # Safety
+///
+/// `e` must point to an `ErrorImpl<E>`.
 unsafe fn object_downcast<E>(e: Ref<'_, ErasedErrorImpl>, target: TypeId) -> Option<Ref<'_, ()>>
 where
     E: 'static,
 {
+    // SAFETY: Required by this function's contract. A pointer is returned only
+    // after confirming that the requested type is `E`.
     unsafe {
         if TypeId::of::<E>() == target {
             // Caller is looking for an E pointer and e is ErrorImpl<E>, take a
@@ -503,7 +556,7 @@ where
 
             Some(
                 Ref::from_raw(NonNull::new_unchecked(
-                    ptr::addr_of!((*unerased.as_ptr())._object) as *mut E
+                    ptr::addr_of!((*unerased.as_ptr()).object).cast_mut(),
                 ))
                 .cast::<()>(),
             )
@@ -515,18 +568,23 @@ where
 
 // repr C to ensure that E remains in the final position.
 #[repr(C)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps erased storage crate-private")]
 pub(crate) struct ErrorImpl<E> {
     vtable: &'static ErrorVTable,
     pub(crate) handler: Option<Box<dyn ReportHandler>>,
     // NOTE: Don't use directly. Use only through vtable. Erased type may have
     // different alignment.
-    _object: E,
+    object: E,
 }
 
 type ErasedErrorImpl = ErrorImpl<()>;
 
-// Safety: `ErrorVTable` must be the first field of `ErrorImpl`
+/// # Safety
+///
+/// `p` must point to an `ErrorImpl`; `ErrorVTable` is its first field.
 unsafe fn vtable(p: NonNull<ErasedErrorImpl>) -> &'static ErrorVTable {
+    // SAFETY: Required by this function's contract and guaranteed by
+    // `ErrorImpl`'s `repr(C)` layout.
     unsafe { (p.as_ptr() as *const &'static ErrorVTable).read() }
 }
 
@@ -543,34 +601,41 @@ impl ErasedErrorImpl {
     pub(crate) unsafe fn error<'a>(
         this: Ref<'a, Self>,
     ) -> &'a (dyn StdError + Send + Sync + 'static) {
+        // SAFETY: The caller guarantees `this` is paired with its original
+        // vtable, whose `as_error` entry reconstructs the correct trait object.
         unsafe {
             // Use vtable to attach E's native StdError vtable for the right
             // original type E.
-            (vtable(this.ptr).object_ref_stderr)(this).deref()
+            (vtable(this.ptr).as_error)(this).deref()
         }
     }
 
     pub(crate) unsafe fn diagnostic<'a>(
         this: Ref<'a, Self>,
     ) -> &'a (dyn Diagnostic + Send + Sync + 'static) {
+        // SAFETY: The caller guarantees `this` is paired with its original
+        // vtable, whose `as_diagnostic` entry reconstructs the trait object.
         unsafe {
             // Use vtable to attach E's native StdError vtable for the right
             // original type E.
-            (vtable(this.ptr).object_ref)(this).deref()
+            (vtable(this.ptr).as_diagnostic)(this).deref()
         }
     }
 
     pub(crate) unsafe fn diagnostic_mut<'a>(
         this: Mut<'a, Self>,
     ) -> &'a mut (dyn Diagnostic + Send + Sync + 'static) {
+        // SAFETY: The caller additionally guarantees exclusive access through
+        // `this`.
         unsafe {
             // Use vtable to attach E's native StdError vtable for the right
             // original type E.
-            (vtable(this.ptr).object_ref)(this.by_ref()).by_mut().deref_mut()
+            (vtable(this.ptr).as_diagnostic)(this.by_ref()).by_mut().deref_mut()
         }
     }
 
     pub(crate) unsafe fn chain(this: Ref<'_, Self>) -> Chain<'_> {
+        // SAFETY: The caller guarantees `this` is a valid erased error.
         unsafe { Chain::new(Self::error(this)) }
     }
 }
@@ -580,6 +645,7 @@ where
     E: StdError,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        // SAFETY: `erase` preserves this allocation's vtable and lifetime.
         unsafe { ErrorImpl::diagnostic(self.erase()).source() }
     }
 }
@@ -591,6 +657,7 @@ where
     E: Debug,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: `erase` preserves this allocation's vtable and lifetime.
         unsafe { ErrorImpl::debug(self.erase(), formatter) }
     }
 }
@@ -600,6 +667,7 @@ where
     E: Display,
 {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // SAFETY: `erase` preserves this allocation's vtable and lifetime.
         unsafe { Display::fmt(ErrorImpl::diagnostic(self.erase()), formatter) }
     }
 }
@@ -607,10 +675,12 @@ where
 impl From<Report> for Box<dyn Diagnostic + Send + Sync + 'static> {
     fn from(error: Report) -> Self {
         let outer = ManuallyDrop::new(error);
+        // SAFETY: `outer` retains its allocation and matching vtable; the
+        // vtable conversion takes ownership exactly once.
         unsafe {
             // Use vtable to attach ErrorImpl<E>'s native StdError vtable for
             // the right original type E.
-            (vtable(outer.inner.ptr).object_boxed)(outer.inner)
+            (vtable(outer.inner.ptr).into_diagnostic)(outer.inner)
         }
     }
 }
@@ -618,10 +688,12 @@ impl From<Report> for Box<dyn Diagnostic + Send + Sync + 'static> {
 impl From<Report> for Box<dyn StdError + Send + Sync + 'static> {
     fn from(error: Report) -> Self {
         let outer = ManuallyDrop::new(error);
+        // SAFETY: `outer` retains its allocation and matching vtable; the
+        // vtable conversion takes ownership exactly once.
         unsafe {
             // Use vtable to attach ErrorImpl<E>'s native StdError vtable for
             // the right original type E.
-            (vtable(outer.inner.ptr).object_boxed_stderr)(outer.inner)
+            (vtable(outer.inner.ptr).into_error)(outer.inner)
         }
     }
 }
@@ -652,12 +724,14 @@ impl AsRef<dyn Diagnostic> for Report {
 
 impl AsRef<dyn StdError + Send + Sync> for Report {
     fn as_ref(&self) -> &(dyn StdError + Send + Sync + 'static) {
+        // SAFETY: `inner` and its matching vtable live as long as `self`.
         unsafe { ErrorImpl::error(self.inner.by_ref()) }
     }
 }
 
 impl AsRef<dyn StdError> for Report {
     fn as_ref(&self) -> &(dyn StdError + 'static) {
+        // SAFETY: `inner` and its matching vtable live as long as `self`.
         unsafe { ErrorImpl::error(self.inner.by_ref()) }
     }
 }

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -27,7 +27,7 @@ struct SpanRequest {
 }
 
 impl SpanRequest {
-    fn new(span: &SourceSpan) -> Self {
+    fn new(span: SourceSpan) -> Self {
         Self { offset: span.offset() as usize, len: span.len() as usize }
     }
 
@@ -374,9 +374,11 @@ impl<'a> SpanReader<'a> {
         let Some(data) = self.input.get(start..self.offset) else {
             return Err(MietteError::OutOfBounds);
         };
+        let span_start = u32::try_from(start).map_err(|_| MietteError::OutOfBounds)?;
+        let span_len = u32::try_from(self.offset - start).map_err(|_| MietteError::OutOfBounds)?;
         Ok(MietteSpanContents::new(
             data,
-            (start as u32, (self.offset - start) as u32).into(),
+            (span_start, span_len).into(),
             self.leading.start_line,
             if self.context.before == 0 { self.start_column } else { 0 },
             self.line_count,
@@ -399,7 +401,7 @@ impl MietteSpanContents<'_> {
     /// primitive so a long (e.g. minified) line stays cheap.
     // Only the `fancy` graphical renderer consumes this today; without it the
     // method is dead in a lib-only build (CI lints `-D warnings`).
-    #[cfg_attr(not(feature = "fancy-base"), allow(dead_code))]
+    #[cfg_attr(all(not(feature = "fancy-base"), not(test)), expect(dead_code))]
     pub(crate) fn line_column_at(&self, offset: usize) -> Option<(usize, usize)> {
         let data = self.data();
         let base = self.span().offset() as usize;
@@ -500,17 +502,14 @@ impl<'a> LineIndex<'a> {
     /// line start after it. `None` at end of input (with `frontier` advanced
     /// there so the probe isn't repeated).
     fn extend(&mut self) -> Option<LineBreak> {
-        match LineBreaks::new(&self.input[self.frontier..]).next() {
-            Some(line_break) => {
-                let line_break = line_break.shifted(self.frontier);
-                self.line_starts.push(line_break.next_line_start());
-                self.frontier = line_break.next_line_start();
-                Some(line_break)
-            }
-            None => {
-                self.frontier = self.input.len();
-                None
-            }
+        if let Some(line_break) = LineBreaks::new(&self.input[self.frontier..]).next() {
+            let line_break = line_break.shifted(self.frontier);
+            self.line_starts.push(line_break.next_line_start());
+            self.frontier = line_break.next_line_start();
+            Some(line_break)
+        } else {
+            self.frontier = self.input.len();
+            None
         }
     }
 
@@ -665,9 +664,11 @@ impl<'index, 'source> IndexedReader<'index, 'source> {
         let Some(data) = self.index.input.get(start..window_end) else {
             return Err(MietteError::OutOfBounds);
         };
+        let span_start = u32::try_from(start).map_err(|_| MietteError::OutOfBounds)?;
+        let span_len = u32::try_from(window_end - start).map_err(|_| MietteError::OutOfBounds)?;
         Ok(MietteSpanContents::new(
             data,
-            (start as u32, (window_end - start) as u32).into(),
+            (span_start, span_len).into(),
             self.leading.start_line,
             if self.context.before == 0 { self.start_column } else { 0 },
             self.line_count,
@@ -687,6 +688,7 @@ impl<'index, 'source> IndexedReader<'index, 'source> {
 /// [`read_span`]: crate::SourceCode::read_span
 /// [`GraphicalReportHandler`]: crate::handlers::GraphicalReportHandler
 #[cfg(feature = "fancy-base")]
+#[expect(clippy::redundant_pub_crate, reason = "keeps the renderer fast path crate-private")]
 pub(crate) struct SpanScanner<'a> {
     context: ContextLines,
     index: LineIndex<'a>,
@@ -708,7 +710,7 @@ impl<'a> SpanScanner<'a> {
     /// Read a span while scanning only source bytes no earlier query scanned.
     pub(crate) fn read_span(
         &mut self,
-        span: &SourceSpan,
+        span: SourceSpan,
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         let request = SpanRequest::new(span);
         let cut = request.prefix_end(self.index.input);
@@ -743,7 +745,7 @@ impl SourceCode for [u8] {
     ) -> Result<MietteSpanContents<'a>, MietteError> {
         SpanReader::new(
             self,
-            SpanRequest::new(span),
+            SpanRequest::new(*span),
             ContextLines::new(context_lines_before, context_lines_after),
         )
         .read()
@@ -996,6 +998,11 @@ mod tests {
 
 #[cfg(test)]
 mod line_column_tests {
+    #![expect(
+        clippy::cast_possible_truncation,
+        reason = "deterministic fuzz inputs are tightly bounded"
+    )]
+
     use super::*;
 
     /// Deterministic xorshift so any failure reproduces from a fixed seed.
@@ -1090,6 +1097,11 @@ mod line_column_tests {
 
 #[cfg(all(test, feature = "fancy-base"))]
 mod scanner_tests {
+    #![expect(
+        clippy::cast_possible_truncation,
+        reason = "deterministic fuzz inputs are tightly bounded"
+    )]
+
     use super::*;
 
     /// Deterministic xorshift so any failure reproduces from a fixed seed.
@@ -1122,13 +1134,10 @@ mod scanner_tests {
         history: &[(usize, usize)],
     ) {
         let source_span: SourceSpan = (span.0 as u32, span.1 as u32).into();
-        let expected = SpanReader::new(
-            input,
-            SpanRequest::new(&source_span),
-            ContextLines::new(before, after),
-        )
-        .read();
-        let got = scanner.read_span(&source_span);
+        let expected =
+            SpanReader::new(input, SpanRequest::new(source_span), ContextLines::new(before, after))
+                .read();
+        let got = scanner.read_span(source_span);
         let src = String::from_utf8_lossy(input);
         match (&expected, &got) {
             (Ok(expected), Ok(got)) => {
@@ -1182,9 +1191,11 @@ mod scanner_tests {
                 }
                 let input = s.as_bytes();
                 for (before, after) in [(0, 0), (1, 1), (2, 2), (0, 2), (2, 0)] {
-                    let mut spans: Vec<(usize, usize)> = (0..6)
-                        .map(|_| (rng.below(input.len() + 3), [0, 1, 2, 5][rng.below(4)]))
-                        .collect();
+                    let mut spans: Vec<(usize, usize)> = std::iter::repeat_with(|| {
+                        (rng.below(input.len() + 3), [0, 1, 2, 5][rng.below(4)])
+                    })
+                    .take(6)
+                    .collect();
 
                     // Random order: queries may jump backwards past the
                     // index origin.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -10,6 +10,7 @@ use crate as miette;
 use crate::{Diagnostic, Report, SourceCode};
 
 #[repr(transparent)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps wrapper internals crate-private")]
 pub(crate) struct MessageError<M>(pub(crate) M);
 
 impl<M> Debug for MessageError<M>
@@ -34,6 +35,7 @@ impl<M> StdError for MessageError<M> where M: Display + Debug + 'static {}
 impl<M> Diagnostic for MessageError<M> where M: Display + Debug + 'static {}
 
 #[repr(transparent)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps wrapper internals crate-private")]
 pub(crate) struct BoxedError(pub(crate) Box<dyn Diagnostic + Send + Sync>);
 
 impl Diagnostic for BoxedError {
@@ -92,16 +94,17 @@ impl StdError for BoxedError {
     }
 
     fn description(&self) -> &str {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.0.description()
     }
 
     fn cause(&self) -> Option<&dyn StdError> {
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         self.0.cause()
     }
 }
 
+#[expect(clippy::redundant_pub_crate, reason = "keeps wrapper internals crate-private")]
 pub(crate) struct WithSourceCode<E, C> {
     pub(crate) error: E,
     pub(crate) source_code: C,

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -1,5 +1,5 @@
-#[rustversion::attr(not(nightly), ignore)]
-#[cfg_attr(miri, ignore)]
+#[rustversion::attr(not(nightly), ignore = "UI diagnostics are pinned to nightly")]
+#[cfg_attr(miri, ignore = "trybuild is unsupported under Miri")]
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -8,18 +8,17 @@ fn related() {
     #[derive(Error, Debug, Diagnostic)]
     #[error("welp")]
     #[diagnostic(code(foo::bar::baz))]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Foo {
         #[related]
         related: Vec<Baz>,
     }
 
     #[derive(Error, Debug, Diagnostic)]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     enum Bar {
         #[error("variant1")]
         #[diagnostic(code(foo::bar::baz))]
-        #[allow(dead_code)]
         Bad {
             #[related]
             related: Vec<Baz>,
@@ -27,13 +26,12 @@ fn related() {
 
         #[error("variant2")]
         #[diagnostic(code(foo::bar::baz))]
-        #[allow(dead_code)]
         LessBad(#[related] Vec<Baz>),
     }
 
     #[derive(Error, Debug, Diagnostic)]
     #[error("welp2")]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Baz;
 }
 
@@ -42,7 +40,7 @@ fn related_report() {
     #[derive(Error, Debug, Diagnostic)]
     #[error("welp")]
     #[diagnostic(code(foo::bar::baz))]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Foo {
         #[related]
         related: Vec<Report>,
@@ -247,7 +245,7 @@ fn test_snippet_named_struct() {
     #[derive(Debug, Diagnostic, Error)]
     #[error("welp")]
     #[diagnostic(code(foo::bar::baz))]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Foo<'a> {
         #[source_code]
         src: &'a str,
@@ -270,7 +268,7 @@ fn test_snippet_unnamed_struct() {
     #[derive(Debug, Diagnostic, Error)]
     #[error("welp")]
     #[diagnostic(code(foo::bar::baz))]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     struct Foo<'a>(
         #[source_code] &'a str,
         #[label("{0}")] SourceSpan,
@@ -285,7 +283,7 @@ fn test_snippet_unnamed_struct() {
 fn test_snippet_enum() {
     #[derive(Debug, Diagnostic, Error)]
     #[error("welp")]
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     enum Foo<'a> {
         #[diagnostic(code(foo::a))]
         A {

--- a/tests/graphical.rs
+++ b/tests/graphical.rs
@@ -1,4 +1,11 @@
 #![cfg(all(feature = "fancy-no-backtrace", not(miri)))]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::needless_pass_by_value,
+    clippy::print_stdout,
+    clippy::unnecessary_wraps,
+    reason = "snapshot fixtures use bounded spans and optional debug output"
+)]
 
 use miette::{
     Diagnostic, GraphicalReportHandler, GraphicalTheme, MietteError, NamedSource,
@@ -34,7 +41,7 @@ fn fmt_report(diag: Report) -> String {
             .with_width(80)
             .render_report(&mut out, diag.as_ref())
             .unwrap();
-    };
+    }
     out
 }
 
@@ -48,7 +55,7 @@ fn fmt_report_with_settings(
 
     handler.render_report(&mut out, diag.as_ref()).unwrap();
 
-    println!("Error:\n```\n{}\n```", out);
+    println!("Error:\n```\n{out}\n```");
 
     out
 }
@@ -414,10 +421,10 @@ fn empty_source() -> Result<(), MietteError> {
         highlight: SourceSpan,
     }
 
-    let src = "".to_string();
+    let src = String::new();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (0, 0).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     // For an empty string, the label cannot be rendered.
     insta::assert_snapshot!(out, @"
 
@@ -457,7 +464,7 @@ b
         small: (14, 1).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
 
     insta::assert_snapshot!(out, @r#"
 
@@ -488,7 +495,7 @@ fn single_line_highlight_span_full_line() {
     }
     let err = MyBad { src: NamedSource::new("issue", "source\ntext"), bad_bit: (7, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
 
     insta::assert_snapshot!(out, @"
 
@@ -517,7 +524,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
     let src = "source\n  👼🏼text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (13, 8).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -551,7 +558,7 @@ fn single_line_with_two_tabs() -> Result<(), MietteError> {
     let src = "source\n\t\ttext\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -585,7 +592,7 @@ fn single_line_with_tab_in_middle() -> Result<(), MietteError> {
     let src = "source\ntext =\ttext\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (14, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -616,7 +623,7 @@ fn single_line_highlight() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -646,7 +653,7 @@ fn external_source() -> Result<(), MietteError> {
     let err = Report::from(MyBad { highlight: (9, 4).into() })
         .with_source_code(NamedSource::new("bad_file.rs", src));
     let out = fmt_report(err);
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -677,7 +684,7 @@ fn single_line_highlight_offset_zero() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (0, 0).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -707,7 +714,7 @@ fn single_line_highlight_offset_end_of_line() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (6, 0).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -737,7 +744,7 @@ fn single_line_highlight_include_end_of_line() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 5).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -768,7 +775,7 @@ fn single_line_highlight_include_end_of_line_crlf() -> Result<(), MietteError> {
     let src = "source\r\n  text\r\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (10, 6).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -799,7 +806,7 @@ fn single_line_highlight_with_empty_span() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 0).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -830,7 +837,7 @@ fn single_line_highlight_no_label() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -860,7 +867,7 @@ fn single_line_highlight_at_line_start() -> Result<(), MietteError> {
     let src = "source\ntext\n  here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (7, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -891,7 +898,7 @@ fn multiline_label() -> Result<(), MietteError> {
     let src = "source\ntext\n  here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (7, 4).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -934,7 +941,7 @@ fn multiple_multi_line_labels() -> Result<(), MietteError> {
         highlight3: (24, 4).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -979,7 +986,7 @@ fn multiple_same_line_highlights() -> Result<(), MietteError> {
         highlight3: (24, 4).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1024,7 +1031,7 @@ fn multiple_same_line_highlights_with_tabs_in_middle() -> Result<(), MietteError
         highlight3: (24, 4).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1057,7 +1064,7 @@ fn multiline_highlight_adjacent() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 11).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1087,7 +1094,7 @@ fn multiline_highlight_multiline_label() -> Result<(), MietteError> {
     let src = "source\n  text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 11).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1117,12 +1124,12 @@ fn multiline_highlight_flyby() -> Result<(), MietteError> {
         highlight2: SourceSpan,
     }
 
-    let src = r#"line1
+    let src = r"line1
 line2
 line3
 line4
 line5
-"#
+"
     .to_string();
     let len = src.len() as u32;
     let err = MyBad {
@@ -1131,7 +1138,7 @@ line5
         highlight2: (10, 9).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1175,12 +1182,12 @@ fn multiline_highlight_no_label() -> Result<(), MietteError> {
     #[error("very much went wrong")]
     struct InnerInner;
 
-    let src = r#"line1
+    let src = r"line1
 line2
 line3
 line4
 line5
-"#
+"
     .to_string();
     let len = src.len() as u32;
     let err = MyBad {
@@ -1190,7 +1197,7 @@ line5
         highlight2: (10, 9).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: wtf?!
@@ -1229,7 +1236,7 @@ fn multiple_multiline_highlights_adjacent() -> Result<(), MietteError> {
         highlight2: (20, 6).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1249,7 +1256,7 @@ fn multiple_multiline_highlights_adjacent() -> Result<(), MietteError> {
 #[test]
 // TODO: This breaks because those highlights aren't "truly" overlapping (in absolute byte offset),
 // but they ARE overlapping in lines. Need to detect the latter case better
-#[ignore]
+#[ignore = "known overlapping highlight rendering failure"]
 /// Lines are overlapping, but the offsets themselves aren't, so they _look_
 /// disjunct if you only look at offsets.
 fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> {
@@ -1272,14 +1279,14 @@ fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> 
         highlight2: (9, 10).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     assert_eq!("Error [oops::my::bad]: oops!\n\n[bad_file.rs] This is the part that broke:\n\n 1 │ source\n 2 │   text\n   ·   ──┬─\n   ·     ╰── this bit here\n 3 │     here\n\n﹦ try doing it better next time?\n".to_string(), out);
     Ok(())
 }
 
 #[test]
 /// Offsets themselves are overlapping, regardless of lines.
-#[ignore]
+#[ignore = "known overlapping highlight rendering failure"]
 fn multiple_multiline_highlights_overlapping_offsets() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]
@@ -1300,7 +1307,7 @@ fn multiple_multiline_highlights_overlapping_offsets() -> Result<(), MietteError
         highlight2: (10, 10).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     assert_eq!("Error [oops::my::bad]: oops!\n\n[bad_file.rs] This is the part that broke:\n\n 1 │ source\n 2 │   text\n   ·   ──┬─\n   ·     ╰── this bit here\n 3 │     here\n\n﹦ try doing it better next time?\n".to_string(), out);
     Ok(())
 }
@@ -1318,7 +1325,7 @@ fn url_links() -> Result<(), MietteError> {
     struct MyBad;
     let err = MyBad;
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     assert!(out.contains("https://example.com"));
     assert!(out.contains("(link)"));
     assert!(out.contains("oops::my::bad"));
@@ -1334,7 +1341,7 @@ fn url_links_no_code() -> Result<(), MietteError> {
     struct MyBad;
     let err = MyBad;
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     assert!(out.contains("https://example.com"));
     assert!(out.contains("(link)"));
     Ok(())
@@ -1354,7 +1361,7 @@ fn disable_url_links() -> Result<(), MietteError> {
     let err = MyBad;
     let mut out = String::new();
     handler().with_links(false).render_report(&mut out, &err).unwrap();
-    println!("Error: {}", out);
+    println!("Error: {out}");
     assert!(out.contains("https://example.com"));
     assert!(!out.contains("(link)"));
     assert!(out.contains("oops::my::bad"));
@@ -1377,7 +1384,7 @@ fn url_links_with_display_text() -> Result<(), MietteError> {
         handler.with_link_display_text("Read the documentation")
     });
 
-    println!("Error: {}", out);
+    println!("Error: {out}");
     assert!(out.contains("https://example.com"));
     assert!(out.contains("Read the documentation"));
     assert!(out.contains("oops::my::bad"));
@@ -1409,7 +1416,7 @@ fn related() -> Result<(), MietteError> {
         }],
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
       × oops::my::bad: oops!
@@ -1465,7 +1472,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
         related: vec![InnerError { highlight: (0, 6).into() }],
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
       × oops::my::bad: oops!
@@ -1567,7 +1574,7 @@ fn related_severity() -> Result<(), MietteError> {
         ],
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
       × oops::my::bad: oops!
@@ -1630,7 +1637,7 @@ fn zero_length_eol_span() {
         bad_bit: (23, 0).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
 
     insta::assert_snapshot!(out, @"
 
@@ -1662,7 +1669,7 @@ fn primary_label() {
         second_label: (24, 4).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
 
     // line 2 should be the primary, not line 1
     insta::assert_snapshot!(out, @"
@@ -1693,7 +1700,7 @@ fn single_line_with_wide_char_unaligned_span_start() -> Result<(), MietteError> 
     let src = "source\n  👼🏼text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (10, 5).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1724,7 +1731,7 @@ fn single_line_with_wide_char_unaligned_span_end() -> Result<(), MietteError> {
     let src = "source\n  text 👼🏼\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 6).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1755,7 +1762,7 @@ fn single_line_with_wide_char_unaligned_span_empty() -> Result<(), MietteError> 
     let src = "source\n  👼🏼text\n    here".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (10, 0).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1795,7 +1802,7 @@ fn triple_adjacent_highlight() -> Result<(), MietteError> {
         highlight3: (22, 4).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1840,7 +1847,7 @@ fn non_adjacent_highlight() -> Result<(), MietteError> {
         highlight2: (12, 4).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::bad: oops!
@@ -1877,7 +1884,7 @@ fn invalid_span_bad_offset() -> Result<(), MietteError> {
     let src = "blabla blibli".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight1: (50, 6).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @r#"
     oops::my::bad
 
@@ -1904,7 +1911,7 @@ fn invalid_span_bad_length() -> Result<(), MietteError> {
     let src = "blabla blibli".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight1: (0, 50).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @r#"
     oops::my::bad
 
@@ -1931,7 +1938,7 @@ fn invalid_span_no_label() -> Result<(), MietteError> {
     let src = "blabla blibli".to_string();
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight1: (50, 6).into() };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @r#"
     oops::my::bad
 
@@ -1964,7 +1971,7 @@ fn invalid_span_2nd_label() -> Result<(), MietteError> {
         highlight2: (50, 6).into(),
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @r#"
     oops::my::bad
 
@@ -2010,7 +2017,7 @@ fn invalid_span_inner() -> Result<(), MietteError> {
         },
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @"
 
      × oops::my::outer: oops outside!
@@ -2060,7 +2067,7 @@ fn invalid_span_related() -> Result<(), MietteError> {
         }],
     };
     let out = fmt_report(err.into());
-    println!("Error: {}", out);
+    println!("Error: {out}");
     insta::assert_snapshot!(out, @r#"
     oops::my::outer
 

--- a/tests/narrated.rs
+++ b/tests/narrated.rs
@@ -1,4 +1,11 @@
 #![cfg(feature = "fancy-no-backtrace")]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::needless_pass_by_value,
+    clippy::print_stdout,
+    clippy::unnecessary_wraps,
+    reason = "snapshot fixtures use bounded spans and optional debug output"
+)]
 
 use miette::{
     Diagnostic, GraphicalReportHandler, GraphicalTheme, MietteError, NamedSource,
@@ -16,7 +23,7 @@ fn fmt_report(diag: Report) -> String {
             .unwrap();
     } else {
         NarratableReportHandler::new().render_report(&mut out, diag.as_ref()).unwrap();
-    };
+    }
     out
 }
 
@@ -36,7 +43,7 @@ fn single_line_with_wide_char() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 6).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -46,7 +53,7 @@ snippet line 2:   👼🏼text
 snippet line 3:     here
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -69,7 +76,7 @@ fn single_line_highlight() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -79,7 +86,7 @@ snippet line 2:   text
 snippet line 3:     here
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -102,7 +109,7 @@ fn single_line_highlight_offset_zero() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (0, 0).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -111,7 +118,7 @@ snippet line 1: source
 snippet line 2:   text
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -134,7 +141,7 @@ fn single_line_highlight_with_empty_span() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 0).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -144,7 +151,7 @@ snippet line 2:   text
 snippet line 3:     here
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -167,7 +174,7 @@ fn single_line_highlight_no_label() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 4).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -177,7 +184,7 @@ snippet line 2:   text
 snippet line 3:     here
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -200,7 +207,7 @@ fn single_line_highlight_at_line_start() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (7, 4).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -210,7 +217,7 @@ snippet line 2: text
 snippet line 3:   here
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -242,7 +249,7 @@ fn multiple_same_line_highlights() -> Result<(), MietteError> {
     };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -254,7 +261,7 @@ snippet line 2:   text text text text text
 snippet line 3:     here
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -277,7 +284,7 @@ fn multiline_highlight_adjacent() -> Result<(), MietteError> {
     let err = MyBad { src: NamedSource::new("bad_file.rs", src), highlight: (9, 11).into() };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -288,7 +295,7 @@ snippet line 3:     here
     label ending at line 3, column 6: these two lines
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -309,12 +316,12 @@ fn multiline_highlight_flyby() -> Result<(), MietteError> {
         highlight2: SourceSpan,
     }
 
-    let src = r#"line1
+    let src = r"line1
 line2
 line3
 line4
 line5
-"#
+"
     .to_string();
     let len = src.len() as u32;
     let err = MyBad {
@@ -324,7 +331,7 @@ line5
     };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -339,7 +346,7 @@ snippet line 5: line5
     label ending at line 5, column 5: block 1
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -372,12 +379,12 @@ fn multiline_highlight_no_label() -> Result<(), MietteError> {
     #[error("very much went wrong")]
     struct InnerInner;
 
-    let src = r#"line1
+    let src = r"line1
 line2
 line3
 line4
 line5
-"#
+"
     .to_string();
     let len = src.len() as u32;
     let err = MyBad {
@@ -462,7 +469,7 @@ diagnostic code: oops::my::bad
 #[test]
 // TODO: This breaks because those highlights aren't "truly" overlapping (in absolute byte offset),
 // but they ARE overlapping in lines. Need to detect the latter case better
-#[ignore]
+#[ignore = "known overlapping highlight rendering failure"]
 /// Lines are overlapping, but the offsets themselves aren't, so they _look_
 /// disjunct if you only look at offsets.
 fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> {
@@ -492,7 +499,7 @@ fn multiple_multiline_highlights_overlapping_lines() -> Result<(), MietteError> 
 
 #[test]
 /// Offsets themselves are overlapping, regardless of lines.
-#[ignore]
+#[ignore = "known overlapping highlight rendering failure"]
 fn multiple_multiline_highlights_overlapping_offsets() -> Result<(), MietteError> {
     #[derive(Debug, Diagnostic, Error)]
     #[error("oops!")]
@@ -557,7 +564,7 @@ fn related() -> Result<(), MietteError> {
     };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -578,7 +585,7 @@ snippet line 1: source
 snippet line 2:   text
 diagnostic help: try doing it better next time?
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);
@@ -615,7 +622,7 @@ fn related_source_code_propagation() -> Result<(), MietteError> {
     };
     let out = fmt_report(err.into());
     println!("Error: {out}");
-    let expected = r#"oops!
+    let expected = r"oops!
     Diagnostic severity: error
 Begin snippet for bad_file.rs starting at line 1, column 1
 
@@ -635,7 +642,7 @@ snippet line 1: source
     label at line 1, columns 1 to 6: this bit here
 snippet line 2:   text
 diagnostic code: oops::my::bad
-"#
+"
     .trim_start()
     .to_string();
     assert_eq!(expected, out);

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "test fixtures are much smaller than u32::MAX"
+)]
+
 //! Tests for the core protocol types. Moved out of `src/protocol.rs` so the
 //! source module carries only library code.
 

--- a/tests/single_scan.rs
+++ b/tests/single_scan.rs
@@ -1,4 +1,8 @@
 #![cfg(feature = "fancy-no-backtrace")]
+#![expect(
+    clippy::cast_possible_truncation,
+    reason = "deterministic fuzz inputs are tightly bounded"
+)]
 //! Differential fuzz test for the graphical renderer's two span-reading paths.
 //!
 //! `render_snippets` reads each label's span either through a shared
@@ -122,7 +126,7 @@ fn buffer_and_read_span_paths_render_identically() {
                 byte
             };
             for context_lines in 0..=2 {
-                let labels: Vec<LabeledSpan> = (0..1 + rng.below(4))
+                let labels: Vec<LabeledSpan> = (0..=rng.below(4))
                     .map(|i| {
                         // One in six labels lands just past EOF, making
                         // the whole render fail; both paths must agree on

--- a/tests/test_boxed.rs
+++ b/tests/test_boxed.rs
@@ -1,3 +1,9 @@
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::unused_self,
+    reason = "test fixtures preserve trait method shape and use bounded spans"
+)]
+
 use std::{error::Error as StdError, io};
 
 use miette::{Diagnostic, LabeledSpan, Report, SourceSpan, SpanContents, miette};

--- a/tests/test_convert.rs
+++ b/tests/test_convert.rs
@@ -15,8 +15,8 @@ fn test_convert() {
 }
 
 #[test]
-#[allow(clippy::unnecessary_wraps)]
 fn test_question_mark() -> Result<(), Box<dyn Diagnostic>> {
+    #[expect(clippy::unnecessary_wraps, reason = "exercises question-mark conversion")]
     fn f() -> Result<()> {
         Ok(())
     }
@@ -36,6 +36,7 @@ fn test_convert_stderr() {
 
 #[test]
 fn test_question_mark_stderr() -> Result<(), Box<dyn std::error::Error>> {
+    #[expect(clippy::unnecessary_wraps, reason = "exercises question-mark conversion")]
     fn f() -> Result<()> {
         Ok(())
     }

--- a/tests/test_derive_collection.rs
+++ b/tests/test_derive_collection.rs
@@ -115,6 +115,7 @@ fn attr_collection_as_linked_list() {
         #[label("this bit here")]
         highlight: SourceSpan,
         #[label(collection, "and here")]
+        #[expect(clippy::linkedlist, reason = "verifies support for non-Vec collections")]
         highlight2: LinkedList<SourceSpan>,
     }
 

--- a/tests/test_diagnostic_source_macro.rs
+++ b/tests/test_diagnostic_source_macro.rs
@@ -85,7 +85,7 @@ fn test_diagnostic_source() {
     assert!(error.diagnostic_source().is_some());
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
 #[error("A nested error happened")]
 struct NestedError {
@@ -97,7 +97,7 @@ struct NestedError {
     the_other_err: Box<dyn Diagnostic>,
 }
 
-#[allow(unused)]
+#[expect(unused)]
 #[derive(Debug, miette::Diagnostic, thiserror::Error)]
 #[error("A multi-error happened")]
 struct MultiError {

--- a/tests/test_emoji_underline.rs
+++ b/tests/test_emoji_underline.rs
@@ -1,4 +1,9 @@
 #![cfg(feature = "fancy-no-backtrace")]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::print_stdout,
+    reason = "visual fixtures use bounded spans and optional debug output"
+)]
 
 use miette::{Diagnostic, GraphicalReportHandler, NamedSource, SourceSpan};
 use thiserror::Error;
@@ -16,9 +21,9 @@ fn test_emoji_sequence_underline() {
 
     // Test with a ZWJ emoji sequence (family emoji)
     let family_emoji = "👨‍👩‍👧‍👦";
-    let src = format!("before {} after", family_emoji);
+    let src = format!("before {family_emoji} after");
     let err = TestError {
-        src: NamedSource::new("test.txt", src.clone()),
+        src: NamedSource::new("test.txt", src),
         span: (7, family_emoji.len() as u32).into(),
     };
 
@@ -26,13 +31,13 @@ fn test_emoji_sequence_underline() {
     GraphicalReportHandler::new().render_report(&mut output, &err).unwrap();
 
     println!("Output for family emoji:");
-    println!("{}", output);
+    println!("{output}");
 
     // Test with flag emoji (also uses ZWJ)
     let flag_emoji = "🏳️‍🌈";
-    let src2 = format!("before {} after", flag_emoji);
+    let src2 = format!("before {flag_emoji} after");
     let err2 = TestError {
-        src: NamedSource::new("test2.txt", src2.clone()),
+        src: NamedSource::new("test2.txt", src2),
         span: (7, flag_emoji.len() as u32).into(),
     };
 
@@ -40,13 +45,13 @@ fn test_emoji_sequence_underline() {
     GraphicalReportHandler::new().render_report(&mut output2, &err2).unwrap();
 
     println!("\nOutput for rainbow flag:");
-    println!("{}", output2);
+    println!("{output2}");
 
     // Test with skin tone modifier
     let skin_tone_emoji = "👋🏽";
-    let src3 = format!("before {} after", skin_tone_emoji);
+    let src3 = format!("before {skin_tone_emoji} after");
     let err3 = TestError {
-        src: NamedSource::new("test3.txt", src3.clone()),
+        src: NamedSource::new("test3.txt", src3),
         span: (7, skin_tone_emoji.len() as u32).into(),
     };
 
@@ -54,13 +59,13 @@ fn test_emoji_sequence_underline() {
     GraphicalReportHandler::new().render_report(&mut output3, &err3).unwrap();
 
     println!("\nOutput for waving hand with skin tone:");
-    println!("{}", output3);
+    println!("{output3}");
 
     // Test ASCII fast path
     let ascii_text = "hello world";
-    let src4 = format!("before {} after", ascii_text);
+    let src4 = format!("before {ascii_text} after");
     let err4 = TestError {
-        src: NamedSource::new("test4.txt", src4.clone()),
+        src: NamedSource::new("test4.txt", src4),
         span: (7, ascii_text.len() as u32).into(),
     };
 
@@ -68,7 +73,7 @@ fn test_emoji_sequence_underline() {
     GraphicalReportHandler::new().render_report(&mut output4, &err4).unwrap();
 
     println!("\nOutput for ASCII text:");
-    println!("{}", output4);
+    println!("{output4}");
 
     // Verify the underline matches the text length
     assert!(output4.contains("hello world"));

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,4 +1,10 @@
-#![allow(clippy::print_stdout, clippy::unnecessary_wraps)]
+#![expect(
+    clippy::cast_possible_truncation,
+    clippy::needless_pass_by_value,
+    clippy::print_stdout,
+    clippy::unnecessary_wraps,
+    reason = "snapshot fixtures use bounded spans and optional debug output"
+)]
 
 mod json_report_handler {
     use miette::{Diagnostic, JSONReportHandler, MietteError, NamedSource, Report, SourceSpan};

--- a/tests/test_note.rs
+++ b/tests/test_note.rs
@@ -183,7 +183,7 @@ mod debug_handler_tests {
         let diag = MietteDiagnostic::new("test message").with_note("test note");
 
         let mut out = String::new();
-        write!(&mut out, "{:?}", diag).unwrap();
+        write!(&mut out, "{diag:?}").unwrap();
 
         assert!(out.contains("note"));
         assert!(out.contains("test note"));
@@ -194,7 +194,7 @@ mod debug_handler_tests {
         let diag = MietteDiagnostic::new("test message");
 
         let mut out = String::new();
-        write!(&mut out, "{:?}", diag).unwrap();
+        write!(&mut out, "{diag:?}").unwrap();
 
         assert!(out.contains("test message"));
     }
@@ -204,7 +204,7 @@ mod debug_handler_tests {
         let diag = MietteDiagnostic::new("message").with_help("help text").with_note("note text");
 
         let mut out = String::new();
-        write!(&mut out, "{:?}", diag).unwrap();
+        write!(&mut out, "{diag:?}").unwrap();
 
         assert!(out.contains("help"));
         assert!(out.contains("help text"));

--- a/tests/wrapper.rs
+++ b/tests/wrapper.rs
@@ -24,7 +24,7 @@ impl Diagnostic for Inner {
 
 #[derive(Error, Debug)]
 #[error("outer")]
-#[allow(unused)]
+#[cfg_attr(not(feature = "fancy"), expect(dead_code))]
 struct Outer {
     pub(crate) errors: Vec<Inner>,
 }


### PR DESCRIPTION
Sync the workspace Rust and Clippy policy with oxc1 and resolve the resulting diagnostics across both crates.

Validation: strict Clippy matrices, Rust 1.85, workspace suite, packaging, and benchmark comparison.