### PR TITLE
perf: restore chunked underline rendering

### DIFF
--- a/src/handlers/graphical/label.rs
+++ b/src/handlers/graphical/label.rs
@@ -38,9 +38,12 @@ const UNICODE_BARS: &str =
 const ASCII_CARETS: &str =
     concat!("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^", "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^");
 
-#[inline]
-fn write_repeated_chunk(f: &mut impl fmt::Write, chunk: &str, mut count: usize) -> fmt::Result {
-    let char_len = chunk.len() / CHUNK_CHARS;
+fn write_repeated_chunk(
+    f: &mut impl fmt::Write,
+    chunk: &str,
+    char_len: usize,
+    mut count: usize,
+) -> fmt::Result {
     while count > CHUNK_CHARS {
         f.write_str(chunk)?;
         count -= CHUNK_CHARS;
@@ -60,7 +63,7 @@ fn write_padding(f: &mut impl fmt::Write, count: usize) -> fmt::Result {
     if count < MIN_CHUNKED_CHARS {
         write_repeated_char(f, ' ', count)
     } else {
-        write_repeated_chunk(f, SPACES, count)
+        write_repeated_chunk(f, SPACES, 1, count)
     }
 }
 
@@ -68,21 +71,21 @@ impl fmt::Display for Underline {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Built-in themes repeat these characters frequently, so emit them in chunks.
         // Preserve the original character loop for custom themes.
-        let Some(underline_chunk) = (match self.line {
-            '─' => Some(UNICODE_BARS),
-            '^' => Some(ASCII_CARETS),
+        let Some((underline_chunk, char_len)) = (match self.line {
+            '─' => Some((UNICODE_BARS, '─'.len_utf8())),
+            '^' => Some((ASCII_CARETS, 1)),
             _ => None,
         }) else {
-            write_padding(f, self.padding)?;
+            write_repeated_char(f, ' ', self.padding)?;
             write_repeated_char(f, self.line, self.left)?;
             f.write_char(self.marker)?;
             return write_repeated_char(f, self.line, self.right);
         };
 
-        write_padding(f, self.padding)?;
-        write_repeated_chunk(f, underline_chunk, self.left)?;
+        write_repeated_chunk(f, SPACES, 1, self.padding)?;
+        write_repeated_chunk(f, underline_chunk, char_len, self.left)?;
         f.write_char(self.marker)?;
-        write_repeated_chunk(f, underline_chunk, self.right)
+        write_repeated_chunk(f, underline_chunk, char_len, self.right)
     }
 }
 
@@ -377,13 +380,13 @@ mod tests {
         for c in [' ', '─', '^', 'x', '🐂'] {
             for count in [0, 1, 31, 32, 33, 64, 65] {
                 let mut output = String::new();
-                if let Some(chunk) = match c {
-                    ' ' => Some(SPACES),
-                    '─' => Some(UNICODE_BARS),
-                    '^' => Some(ASCII_CARETS),
+                if let Some((chunk, char_len)) = match c {
+                    ' ' => Some((SPACES, 1)),
+                    '─' => Some((UNICODE_BARS, '─'.len_utf8())),
+                    '^' => Some((ASCII_CARETS, 1)),
                     _ => None,
                 } {
-                    write_repeated_chunk(&mut output, chunk, count).unwrap();
+                    write_repeated_chunk(&mut output, chunk, char_len, count).unwrap();
                 } else {
                     write_repeated_char(&mut output, c, count).unwrap();
                 }


### PR DESCRIPTION
Restores specialized chunk writes in underline formatting to prevent the renderer regression introduced by #282.