### PR TITLE
perf: batch report rendering to share line scans

### DIFF
--- a/benches/render.rs
+++ b/benches/render.rs
@@ -25,8 +25,8 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
 use miette::{
-    Error, GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic, NamedSource,
-    Severity, SourceCode, SourceSpan,
+    Diagnostic, Error, GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic,
+    NamedSource, Severity, SourceCode, SourceSpan,
 };
 
 /// Pinned revision of <https://github.com/oxc-project/benchmark-files>, so the
@@ -267,6 +267,60 @@ fn bench(c: &mut Criterion) {
         }
         group.finish();
     }
+
+    // A file with several diagnostics renders them in one batch: oxlint sends
+    // one `Vec` of wrapped diagnostics per file. `sequential` renders each
+    // report standalone, paying one full prefix scan per report; `batched`
+    // shares the scan across the batch through `render_reports`.
+    let mut group = c.benchmark_group("render_batch/ci");
+    let handler = ci_handler();
+    for fixture in &fixtures {
+        let diagnostics: Vec<Error> = [0.2, 0.4, 0.6, 0.8]
+            .iter()
+            .map(|&fraction| {
+                let offset = (fixture.source_len as f64 * fraction) as usize;
+                let span = identifier_span_at(fixture.source.inner(), offset);
+                let diagnostic = lint_diagnostic(
+                    "Variable 'resolve' is declared but never used.",
+                    "Consider removing this declaration.",
+                )
+                .with_label(LabeledSpan::new_with_span(
+                    Some("'resolve' is declared here".to_string()),
+                    span,
+                ));
+                Error::new(diagnostic).with_source_code(Arc::clone(&fixture.source))
+            })
+            .collect();
+        let refs: Vec<&dyn Diagnostic> =
+            diagnostics.iter().map(|diagnostic| diagnostic.as_ref() as &dyn Diagnostic).collect();
+
+        group.throughput(Throughput::Bytes(fixture.source_len as u64));
+        group.bench_function(BenchmarkId::new("sequential", fixture.name), |b| {
+            b.iter(|| {
+                let mut outputs = Vec::with_capacity(refs.len());
+                for diagnostic in &refs {
+                    let mut out = String::new();
+                    handler
+                        .render_report(&mut out, black_box(*diagnostic))
+                        .expect("render succeeds");
+                    outputs.push(out);
+                }
+                outputs
+            });
+        });
+        group.bench_function(BenchmarkId::new("batched", fixture.name), |b| {
+            b.iter(|| {
+                handler
+                    .render_reports(black_box(&refs))
+                    .map(|(result, out)| {
+                        result.expect("render succeeds");
+                        out
+                    })
+                    .collect::<Vec<_>>()
+            });
+        });
+    }
+    group.finish();
 }
 
 criterion_group!(

--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -13,7 +13,7 @@ use std::fmt::{self, Write};
 use owo_colors::OwoColorize;
 
 use super::handler::{GraphicalReportHandler, LinkStyle};
-use crate::{Diagnostic, Severity, SourceCode};
+use crate::{Diagnostic, Severity, SourceCode, source_impls::ScanSeed};
 
 impl GraphicalReportHandler {
     /// Render a [`Diagnostic`]. This function is mostly internal and meant to
@@ -29,20 +29,74 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
     ) -> fmt::Result {
-        writeln!(f)?;
-        self.render_causes(f, diagnostic)?;
-        let src = diagnostic.source_code();
-        self.render_snippets(f, diagnostic, src)?;
-        self.render_footer(f, diagnostic)?;
-        self.render_related(f, diagnostic, src)?;
-        if let Some(footer) = &self.footer {
+        self.render_report_carry(f, diagnostic, None).0
+    }
+
+    /// Render each of `diagnostics` in sequence, scanning each shared source
+    /// once across them.
+    ///
+    /// Yields one `(result, rendered)` pair per diagnostic, matching
+    /// [`render_report`](Self::render_report) byte for byte. Consecutive
+    /// diagnostics whose sources expose the same backing buffer (the same
+    /// [`contiguous_bytes`](crate::SourceCode::contiguous_bytes) pointer and
+    /// length) share one line scan: the first report scans the source's
+    /// prefix, and each later one reads only the bytes between the previous
+    /// report's span and its own — the dominant cost of rendering several
+    /// diagnostics against one large source, which is how a linter reports a
+    /// file. The iterator is lazy, so callers can stop early without paying
+    /// for unrendered reports.
+    pub fn render_reports<'h, 'd>(
+        &'h self,
+        diagnostics: &'d [&'d dyn Diagnostic],
+    ) -> impl Iterator<Item = (fmt::Result, String)> + use<'h, 'd> {
+        let mut carry: Option<((*const u8, usize), ScanSeed)> = None;
+        diagnostics.iter().map(move |diagnostic| {
+            let id = diagnostic
+                .source_code()
+                .and_then(SourceCode::contiguous_bytes)
+                .map(|bytes| (bytes.as_ptr(), bytes.len()));
+            // Sharing is keyed by buffer identity, which the borrow of
+            // `diagnostics` keeps stable for the iterator's lifetime.
+            let resume = match (&carry, &id) {
+                (Some((carry_id, seed)), Some(id)) if carry_id == id => Some(*seed),
+                _ => None,
+            };
+            let mut out = String::new();
+            let (result, memo) = self.render_report_carry(&mut out, *diagnostic, resume);
+            carry = id.zip(memo);
+            (result, out)
+        })
+    }
+
+    /// [`render_report`](Self::render_report) with the cross-report scan memo
+    /// threaded through: `resume` is the previous report's memo over the same
+    /// source, and the returned memo is this report's, for the next one.
+    /// Stages after the snippets can fail once the memo already exists, so it
+    /// is returned alongside the result instead of through `?`.
+    fn render_report_carry(
+        &self,
+        f: &mut impl fmt::Write,
+        diagnostic: &dyn Diagnostic,
+        resume: Option<ScanSeed>,
+    ) -> (fmt::Result, Option<ScanSeed>) {
+        let mut memo = None;
+        let result = (|| {
             writeln!(f)?;
-            let width = self.termwidth.saturating_sub(4);
-            let opts = self.wrap_options(width, "  ", "  ");
-            self.write_wrap(f, footer, opts)?;
-            f.write_char('\n')?;
-        }
-        Ok(())
+            self.render_causes(f, diagnostic)?;
+            let src = diagnostic.source_code();
+            memo = self.render_snippets(f, diagnostic, src, resume)?;
+            self.render_footer(f, diagnostic)?;
+            self.render_related(f, diagnostic, src)?;
+            if let Some(footer) = &self.footer {
+                writeln!(f)?;
+                let width = self.termwidth.saturating_sub(4);
+                let opts = self.wrap_options(width, "  ", "  ");
+                self.write_wrap(f, footer, opts)?;
+                f.write_char('\n')?;
+            }
+            Ok(())
+        })();
+        (result, memo)
     }
 
     fn render_header(&self, f: &mut impl fmt::Write, diagnostic: &dyn Diagnostic) -> fmt::Result {
@@ -188,7 +242,7 @@ impl GraphicalReportHandler {
                 inner_renderer.render_header(f, rel)?;
                 inner_renderer.render_causes(f, rel)?;
                 let src = rel.source_code().or(parent_src);
-                inner_renderer.render_snippets(f, rel, src)?;
+                inner_renderer.render_snippets(f, rel, src, None)?;
                 inner_renderer.render_footer(f, rel)?;
                 inner_renderer.render_related(f, rel, src)?;
             }

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -19,31 +19,37 @@ use super::{
 };
 use crate::{
     Diagnostic, LabeledSpan, MietteSpanContents, SourceCode, SourceSpan, SpanContents,
-    source_impls::SpanScanner,
+    source_impls::{ScanSeed, SpanScanner},
 };
 
 impl GraphicalReportHandler {
+    /// Renders the diagnostic's snippets and returns the memoizable state of
+    /// the source scan they shared, which a caller rendering several reports
+    /// against one source passes back in as the next report's `resume` (see
+    /// [`render_reports`](GraphicalReportHandler::render_reports)).
     pub(super) fn render_snippets(
         &self,
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
         opt_source: Option<&dyn SourceCode>,
-    ) -> fmt::Result {
-        let Some(source) = opt_source else { return Ok(()) };
+        resume: Option<ScanSeed>,
+    ) -> Result<Option<ScanSeed>, fmt::Error> {
+        let Some(source) = opt_source else { return Ok(None) };
         let mut labels = diagnostic.labels();
         if labels.is_empty() {
-            return Ok(());
+            return Ok(None);
         }
         labels.sort_unstable_by_key(|l| l.inner().offset());
 
         // When the source exposes its backing buffer, share one forward scan
         // across every span lookup below (one per label plus one per merge
         // attempt); each `read_span` otherwise scans the source from byte 0
-        // again. The scanner bypasses the source's own `read_span`, so
-        // re-attach the source's name the way `NamedSource` would.
+        // again. `resume` carries that scan across reports in turn. The
+        // scanner bypasses the source's own `read_span`, so re-attach the
+        // source's name the way `NamedSource` would.
         let mut scanner = source
             .contiguous_bytes()
-            .map(|bytes| SpanScanner::new(bytes, self.context_lines, self.context_lines));
+            .map(|bytes| SpanScanner::new(bytes, self.context_lines, self.context_lines, resume));
         let source_name = source.name();
         let mut read = |span: &SourceSpan| match scanner.as_mut() {
             Some(scanner) => scanner.read_span(*span).map(|contents| match source_name {
@@ -62,7 +68,9 @@ impl GraphicalReportHandler {
 
         if let [label] = labels.as_slice() {
             let contents = read(label.inner()).map_err(|_| fmt::Error)?;
-            return self.render_context(f, label, &contents, &labels);
+            let memo = scanner.as_ref().and_then(SpanScanner::memo);
+            self.render_context(f, label, &contents, &labels)?;
+            return Ok(memo);
         }
 
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
@@ -96,11 +104,12 @@ impl GraphicalReportHandler {
 
             contexts.push((Cow::Borrowed(right), right_conts));
         }
+        let memo = scanner.as_ref().and_then(SpanScanner::memo);
         for (ctx, conts) in contexts {
             self.render_context(f, &ctx, &conts, &labels[..])?;
         }
 
-        Ok(())
+        Ok(memo)
     }
 
     pub(super) fn render_context(

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -199,6 +199,59 @@ impl LeadingContext {
     }
 }
 
+/// Whether `pos` sits between the `\r` and `\n` of a CRLF pair — inside a
+/// logical break rather than on either side of one.
+fn splits_crlf_pair(input: &[u8], pos: usize) -> bool {
+    pos > 0 && input[pos - 1] == b'\r' && input.get(pos) == Some(&b'\n')
+}
+
+/// Bulk newline count. `bytecount` dispatches to SIMD intrinsics Miri cannot
+/// interpret (NEON on aarch64), so Miri counts bytewise instead.
+#[expect(
+    clippy::naive_bytecount,
+    reason = "the naive branch exists because `bytecount` is uninterpretable under Miri"
+)]
+fn count_newlines(haystack: &[u8]) -> usize {
+    if cfg!(miri) {
+        haystack.iter().filter(|&&byte| byte == b'\n').count()
+    } else {
+        bytecount::count(haystack, b'\n')
+    }
+}
+
+/// A prefix scan's state at a source position, compact enough to memoize.
+///
+/// Holds everything a later scan of the same source needs to continue from
+/// `pos` instead of byte 0: how many line breaks precede `pos` and where the
+/// last two lines start. Producers never extract one at a position that
+/// splits a `\r\n` pair, so resuming never double-counts a break.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps the scan memo crate-private")]
+pub(crate) struct ScanSeed {
+    /// Bytes in `[0, pos)` are summarized by the fields below.
+    pos: usize,
+    /// Line breaks in `[0, pos)`.
+    line_count: usize,
+    /// Start of the line before the one containing `pos`. `None` while
+    /// `line_count` is 0, mirroring [`PrefixScan::one_context_line_resumed`].
+    previous_line_start: Option<usize>,
+    /// Start of the line containing `pos`.
+    current_line_start: usize,
+}
+
+impl ScanSeed {
+    /// The state of every scan before it has consumed any input.
+    const START: Self =
+        Self { pos: 0, line_count: 0, previous_line_start: None, current_line_start: 0 };
+
+    /// How much of the source this seed summarizes. A seed with a larger
+    /// position saves later scans more work.
+    #[cfg(all(test, feature = "fancy-base"))]
+    pub(crate) fn pos(&self) -> usize {
+        self.pos
+    }
+}
+
 /// State produced by scanning the source prefix before a span.
 struct PrefixScan {
     line_count: usize,
@@ -207,12 +260,15 @@ struct PrefixScan {
 }
 
 impl PrefixScan {
-    /// Scan the prefix before a span, retaining only its leading context lines.
+    /// Scan the prefix before a span, retaining only its leading context
+    /// lines. A `seed` memoized by an earlier scan of the same source lets
+    /// the one-context-line scan read only `[seed.pos, end)`; other widths
+    /// ignore it.
     #[inline]
-    fn new(input: &[u8], end: usize, context_lines_before: usize) -> Self {
+    fn new(input: &[u8], end: usize, context_lines_before: usize, seed: Option<ScanSeed>) -> Self {
         let prefix = &input[..end];
         if context_lines_before == 1 {
-            return Self::one_context_line(prefix);
+            return Self::one_context_line_resumed(prefix, seed.unwrap_or(ScanSeed::START));
         }
 
         let mut scan = Self {
@@ -228,27 +284,47 @@ impl PrefixScan {
         scan
     }
 
-    /// The graphical handler's default. Keep the one retained line start in a
-    /// scalar while scanning instead of updating a `VecDeque` for every line.
-    fn one_context_line(prefix: &[u8]) -> Self {
-        let mut line_count = 0;
-        let mut current_line_start = 0;
-        let mut previous_line_start = None;
+    /// The graphical handler's default width, continued from `seed` so only
+    /// `prefix[seed.pos..]` is read (a fresh scan resumes from
+    /// [`ScanSeed::START`]). Most source files only use LF: count all breaks
+    /// in that delta with one SIMD pass, then recover the two line starts the
+    /// caller needs from its end. A delta containing `\r` walks its breaks
+    /// one by one instead, since `\n` counting would miss lone-`\r` breaks.
+    fn one_context_line_resumed(prefix: &[u8], seed: ScanSeed) -> Self {
+        // A seed from another source could be deeper than this prefix; treat
+        // it as absent rather than slicing out of bounds.
+        let seed = if seed.pos <= prefix.len() { seed } else { ScanSeed::START };
+        debug_assert!(
+            !splits_crlf_pair(prefix, seed.pos),
+            "a seed inside a CRLF pair would count its break twice"
+        );
+        let delta = &prefix[seed.pos..];
 
-        if memchr::memchr(b'\r', prefix).is_none() {
-            // Most source files only use LF. Count all breaks in one SIMD pass,
-            // then recover the two line starts the caller needs from the end.
-            line_count = bytecount::count(prefix, b'\n');
-            if let Some(last_break) = memchr::memrchr(b'\n', prefix) {
-                current_line_start = last_break + 1;
-                previous_line_start =
-                    Some(memchr::memrchr(b'\n', &prefix[..last_break]).map_or(0, |pos| pos + 1));
-            }
-        } else {
-            for line_break in LineBreaks::new(prefix) {
+        let mut line_count = seed.line_count;
+        let mut previous_line_start = seed.previous_line_start;
+        let mut current_line_start = seed.current_line_start;
+        if memchr::memchr(b'\r', delta).is_some() {
+            for line_break in LineBreaks::new(delta) {
                 line_count += 1;
                 previous_line_start = Some(current_line_start);
-                current_line_start = line_break.next_line_start();
+                current_line_start = seed.pos + line_break.next_line_start();
+            }
+        } else {
+            let breaks = count_newlines(delta);
+            if breaks > 0 {
+                let last_break =
+                    memchr::memrchr(b'\n', delta).expect("delta contains counted breaks");
+                previous_line_start = Some(if breaks == 1 {
+                    // The delta's only break: the line it ends was the seed's
+                    // current line (line 0 starting at 0 for a fresh scan).
+                    seed.current_line_start
+                } else {
+                    let second_to_last = memchr::memrchr(b'\n', &delta[..last_break])
+                        .expect("delta contains counted breaks");
+                    seed.pos + second_to_last + 1
+                });
+                current_line_start = seed.pos + last_break + 1;
+                line_count += breaks;
             }
         }
 
@@ -302,7 +378,7 @@ impl<'a> SpanReader<'a> {
     fn new(input: &'a [u8], request: SpanRequest, context: ContextLines) -> Self {
         let offset = request.prefix_end(input);
         let PrefixScan { line_count, leading, current_line_start } =
-            PrefixScan::new(input, offset, context.before);
+            PrefixScan::new(input, offset, context.before, None);
         Self {
             input,
             request,
@@ -467,16 +543,46 @@ impl<'a> LineIndex<'a> {
     }
 
     /// First query: retain the line starts in its leading context window and
-    /// use them as the origin of the reusable index.
-    fn init(&mut self, cut: usize, context_lines_before: usize) {
+    /// use them as the origin of the reusable index. A `seed` memoized by an
+    /// earlier scan of the same source lets the prefix scan read only
+    /// `[seed.pos, cut)` instead of starting at byte 0.
+    fn init(&mut self, cut: usize, context_lines_before: usize, seed: Option<ScanSeed>) {
         let PrefixScan { line_count, leading, current_line_start } =
-            PrefixScan::new(self.input, cut, context_lines_before);
+            PrefixScan::new(self.input, cut, context_lines_before, seed);
         debug_assert_eq!(leading.start_line + leading.len(), line_count);
         self.base_line = leading.start_line;
         self.line_starts.reserve(leading.len() + 8);
         leading.append_to(&mut self.line_starts);
         self.line_starts.push(current_line_start);
         self.frontier = cut;
+    }
+
+    /// The scan state at `frontier`, for memoization by [`ScanSeed`]: every
+    /// break in `[0, frontier)` is summed into `base_line` or recorded in
+    /// `line_starts`, whose last two entries are the line starts a seed
+    /// carries. `None` when the index does not determine one — nothing was
+    /// scanned, or a zero-width leading context retained a single start with
+    /// unrecorded lines before it.
+    fn seed(&self) -> Option<ScanSeed> {
+        debug_assert!(
+            !splits_crlf_pair(self.input, self.frontier),
+            "the frontier never splits a CRLF pair"
+        );
+        match self.line_starts.as_slice() {
+            [.., previous, current] => Some(ScanSeed {
+                pos: self.frontier,
+                line_count: self.base_line + self.line_starts.len() - 1,
+                previous_line_start: Some(*previous),
+                current_line_start: *current,
+            }),
+            [start] if self.base_line == 0 => Some(ScanSeed {
+                pos: self.frontier,
+                line_count: 0,
+                previous_line_start: None,
+                current_line_start: *start,
+            }),
+            _ => None,
+        }
     }
 
     /// Extend the index so every break in `[0, target)` is recorded, with one
@@ -692,19 +798,42 @@ impl<'index, 'source> IndexedReader<'index, 'source> {
 pub(crate) struct SpanScanner<'a> {
     context: ContextLines,
     index: LineIndex<'a>,
+    /// State memoized by an earlier scanner over the same bytes, consumed by
+    /// the first query's prefix scan.
+    resume: Option<ScanSeed>,
+    /// This scanner's own state at its first query's prefix cut, for a later
+    /// scanner to resume from. Memoizing this position — not the deeper
+    /// index frontier — keeps the memo usable by a repeat of the same query,
+    /// whose cut would fall short of the frontier and force a fresh scan.
+    memo: Option<ScanSeed>,
 }
 
 #[cfg(feature = "fancy-base")]
 impl<'a> SpanScanner<'a> {
+    /// A scanner over `input`. When `resume` is `Some` — state memoized by
+    /// [`SpanScanner::memo`] on an earlier scanner over the same bytes — the
+    /// first query's prefix scan resumes from it instead of starting at
+    /// byte 0.
     pub(crate) fn new(
         input: &'a [u8],
         context_lines_before: usize,
         context_lines_after: usize,
+        resume: Option<ScanSeed>,
     ) -> Self {
         Self {
             context: ContextLines::new(context_lines_before, context_lines_after),
             index: LineIndex::new(input),
+            resume,
+            memo: None,
         }
+    }
+
+    /// The memoizable state of this scanner's first prefix scan, replacing a
+    /// later scanner's scan of the source prefix with two bulk reads of the
+    /// bytes between this position and its first query. `None` before the
+    /// first query (or when that query's scan does not determine one).
+    pub(crate) fn memo(&self) -> Option<ScanSeed> {
+        self.memo
     }
 
     /// Read a span while scanning only source bytes no earlier query scanned.
@@ -715,7 +844,12 @@ impl<'a> SpanScanner<'a> {
         let request = SpanRequest::new(span);
         let cut = request.prefix_end(self.index.input);
         if self.index.is_empty() {
-            self.index.init(cut, self.context.before);
+            // Only the one-context-line scan understands seeds.
+            let seed = if self.context.before == 1 { self.resume.take() } else { None };
+            self.index.init(cut, self.context.before, seed);
+            // The index still sits exactly at `cut`; later queries deepen it
+            // past positions a repeated query could resume from.
+            self.memo = self.index.seed();
         } else {
             if cut < self.index.origin().expect("a non-empty index has an origin") {
                 return self.read_unindexed(request);
@@ -892,12 +1026,59 @@ mod tests {
     fn lf_prefix_fast_path_matches_generic_path() {
         let input = b"zero\none\n\ntwo\nthree\n";
         for cut in 0..=input.len() {
-            let fast = PrefixScan::new(input, cut, 1);
-            let generic = PrefixScan::new(input, cut, 2);
+            let fast = PrefixScan::new(input, cut, 1, None);
+            let generic = PrefixScan::new(input, cut, 2, None);
             assert_eq!(fast.line_count, generic.line_count, "cut={cut}");
             assert_eq!(fast.current_line_start, generic.current_line_start, "cut={cut}");
             assert_eq!(fast.leading.first(), generic.leading.last(), "cut={cut}");
             assert_eq!(fast.leading.start_line, fast.line_count.saturating_sub(1), "cut={cut}");
+        }
+    }
+
+    /// A scan resumed from a memoized [`ScanSeed`] must match the scan that
+    /// starts at byte 0, for every (memo position, scan end) combination
+    /// across LF / CRLF / lone-CR / multibyte inputs. Seeds are a scan's own
+    /// state at its end, so the test rebuilds one from the fresh scan at each
+    /// position — skipping positions inside a `\r\n` pair, where no producer
+    /// creates one.
+    #[test]
+    fn resumed_prefix_scan_matches_fresh_scan() {
+        let inputs: &[&[u8]] = &[
+            b"",
+            b"a",
+            b"one line only",
+            b"zero\none\n\ntwo\nthree\n",
+            b"a\r\nb\r\nc",
+            b"a\rb\rc",
+            b"mixed\r\nlf\nlone\rend",
+            b"\n\n\n",
+            b"\r\r\r",
+            b"\r\n\r\n",
+            b"ends with pair\r\n",
+            "caf\u{e9}\nn\u{1f402}ext\n".as_bytes(),
+        ];
+        for &input in inputs {
+            for mid in 0..=input.len() {
+                if splits_crlf_pair(input, mid) {
+                    continue;
+                }
+                let at_mid = PrefixScan::new(input, mid, 1, None);
+                let seed = ScanSeed {
+                    pos: mid,
+                    line_count: at_mid.line_count,
+                    previous_line_start: at_mid.leading.last(),
+                    current_line_start: at_mid.current_line_start,
+                };
+                for cut in mid..=input.len() {
+                    let context = format!("input={input:?} mid={mid} cut={cut}");
+                    let resumed = PrefixScan::one_context_line_resumed(&input[..cut], seed);
+                    let fresh = PrefixScan::new(input, cut, 1, None);
+                    assert_eq!(resumed.line_count, fresh.line_count, "{context}");
+                    assert_eq!(resumed.current_line_start, fresh.current_line_start, "{context}");
+                    assert_eq!(resumed.leading.start_line, fresh.leading.start_line, "{context}");
+                    assert_eq!(resumed.leading.first(), fresh.leading.first(), "{context}");
+                }
+            }
         }
     }
 
@@ -1120,6 +1301,31 @@ mod scanner_tests {
         }
     }
 
+    /// Line-ending mixes the differential fuzzers sweep: LF-only, CRLF,
+    /// lone-CR, and multibyte text around all three.
+    const ALPHABETS: &[&[&str]] = &[
+        &["a", "\n"],
+        &["a", "b", "c", "\n"],
+        &["a", "b", "\r\n"],
+        &["a", "\r", "\n", "\r\n"],
+        &["x", "y", "\n", "é", "🦀", "\r\n"],
+    ];
+
+    /// A random source of up to 15 segments drawn from `alpha`.
+    fn random_input(rng: &mut Rng, alpha: &[&str]) -> String {
+        let n = rng.below(16);
+        let mut s = String::new();
+        for _ in 0..n {
+            s.push_str(alpha[rng.below(alpha.len())]);
+        }
+        s
+    }
+
+    /// A random span of any byte alignment, including past-EOF ones.
+    fn random_span(rng: &mut Rng, input_len: usize) -> (usize, usize) {
+        (rng.below(input_len + 3), [0, 1, 2, 5][rng.below(4)])
+    }
+
     /// Run one query against a (stateful) scanner and assert the result is
     /// identical to a fresh `SpanReader` — data, span, line, column, and
     /// `line_count` on success, `OutOfBounds` on failure. `history` is the
@@ -1173,33 +1379,21 @@ mod scanner_tests {
                   exercised under Miri by the normal snapshot tests"
     )]
     fn scanner_matches_span_reader_exhaustively() {
-        let alphabets: &[&[&str]] = &[
-            &["a", "\n"],
-            &["a", "b", "c", "\n"],
-            &["a", "b", "\r\n"],
-            &["a", "\r", "\n", "\r\n"],
-            &["x", "y", "\n", "é", "🦀", "\r\n"],
-        ];
         let mut rng = Rng(0xA076_1D64_78BD_642F);
         let mut checked = 0usize;
-        for alpha in alphabets {
+        for alpha in ALPHABETS {
             for _ in 0..700 {
-                let n = rng.below(16);
-                let mut s = String::new();
-                for _ in 0..n {
-                    s.push_str(alpha[rng.below(alpha.len())]);
-                }
+                let s = random_input(&mut rng, alpha);
                 let input = s.as_bytes();
                 for (before, after) in [(0, 0), (1, 1), (2, 2), (0, 2), (2, 0)] {
-                    let mut spans: Vec<(usize, usize)> = std::iter::repeat_with(|| {
-                        (rng.below(input.len() + 3), [0, 1, 2, 5][rng.below(4)])
-                    })
-                    .take(6)
-                    .collect();
+                    let mut spans: Vec<(usize, usize)> =
+                        std::iter::repeat_with(|| random_span(&mut rng, input.len()))
+                            .take(6)
+                            .collect();
 
                     // Random order: queries may jump backwards past the
                     // index origin.
-                    let mut scanner = SpanScanner::new(input, before, after);
+                    let mut scanner = SpanScanner::new(input, before, after, None);
                     for i in 0..spans.len() {
                         check(&mut scanner, input, spans[i], before, after, &spans[..i]);
                         checked += 1;
@@ -1212,7 +1406,7 @@ mod scanner_tests {
                     let first = spans[0].0;
                     let merged_end = spans.iter().map(|&(o, l)| o + l).max().unwrap();
                     spans.push((first, merged_end - first));
-                    let mut scanner = SpanScanner::new(input, before, after);
+                    let mut scanner = SpanScanner::new(input, before, after, None);
                     for i in 0..spans.len() {
                         check(&mut scanner, input, spans[i], before, after, &spans[..i]);
                         checked += 1;
@@ -1223,14 +1417,77 @@ mod scanner_tests {
         assert!(checked > 100_000, "expected a broad sweep, only checked {checked}");
     }
 
+    /// Differentially fuzz the memo hand-off: a scanner resuming from an
+    /// earlier scanner's memo must answer every query exactly like a fresh
+    /// `SpanReader`, across scanner generations threading one seed (as a
+    /// batch of reports against one source does), context configurations
+    /// (memos are produced and consumed by handlers with different context
+    /// widths), and memos gone stale (kept from an older generation).
+    #[test]
+    #[cfg_attr(
+        miri,
+        ignore = "equivalence fuzzer over safe, bounds-checked code — Miri finds no UB here \
+                  and interprets it orders of magnitude slower; the seeded path is still \
+                  exercised under Miri by `resumed_prefix_scan_matches_fresh_scan` and the \
+                  render tests"
+    )]
+    fn seeded_scanner_matches_span_reader_exhaustively() {
+        let configs = [(1usize, 1usize), (1, 0), (0, 1), (2, 2)];
+        let mut rng = Rng(0x517C_C1B7_2722_0A95);
+        let mut resumed = 0usize;
+        for alpha in ALPHABETS {
+            for _ in 0..500 {
+                let s = random_input(&mut rng, alpha);
+                let input = s.as_bytes();
+                let mut seed = None;
+                for _generation in 0..3 {
+                    let (before, after) = configs[rng.below(configs.len())];
+                    resumed += usize::from(before == 1 && seed.is_some());
+                    let mut scanner = SpanScanner::new(input, before, after, seed);
+                    let mut history = Vec::new();
+                    for _ in 0..4 {
+                        let span = random_span(&mut rng, input.len());
+                        check(&mut scanner, input, span, before, after, &history);
+                        history.push(span);
+                    }
+                    // Keep the previous generation's memo when this scanner
+                    // withholds one; it describes the same bytes, so handing
+                    // it to the next generation must stay sound.
+                    seed = scanner.memo().or(seed);
+                }
+            }
+        }
+        assert!(resumed > 1_500, "expected the memoized path to engage, resumed {resumed}");
+    }
+
+    /// The memo records the first query's prefix cut — so repeating the same
+    /// query resumes with an empty delta — and resuming an earlier query from
+    /// it stays correct by falling back to a fresh scan.
+    #[test]
+    fn memo_records_the_first_querys_cut() {
+        let input = b"a\nb\nc\nd\n";
+
+        let mut scanner = SpanScanner::new(input, 1, 1, None);
+        assert!(scanner.memo().is_none());
+        scanner.read_span((6, 1).into()).unwrap();
+        let memo = scanner.memo().expect("the first query memoizes its scan");
+        assert_eq!(memo.pos(), 5);
+
+        // An earlier query cannot resume from the deeper memo; its answers
+        // must still be exact (`check` compares against a fresh SpanReader).
+        let mut scanner = SpanScanner::new(input, 1, 1, Some(memo));
+        check(&mut scanner, input, (2, 1), 1, 1, &[]);
+        assert_eq!(scanner.memo().expect("memoized").pos(), 1);
+    }
+
     /// The empty-source and just-past-EOF edge cases `SpanReader` special
     /// cases, issued through one scanner.
     #[test]
     fn zero_length_spans_at_eof() {
-        let mut scanner = SpanScanner::new(b"", 0, 0);
+        let mut scanner = SpanScanner::new(b"", 0, 0, None);
         check(&mut scanner, b"", (0, 0), 0, 0, &[]);
         check(&mut scanner, b"", (1, 0), 0, 0, &[(0, 0)]);
-        let mut scanner = SpanScanner::new(b"a", 1, 1);
+        let mut scanner = SpanScanner::new(b"a", 1, 1, None);
         check(&mut scanner, b"a", (1, 0), 1, 1, &[]);
         check(&mut scanner, b"a", (2, 0), 1, 1, &[(1, 0)]);
     }

--- a/tests/single_scan.rs
+++ b/tests/single_scan.rs
@@ -3,14 +3,16 @@
     clippy::cast_possible_truncation,
     reason = "deterministic fuzz inputs are tightly bounded"
 )]
-//! Differential fuzz test for the graphical renderer's two span-reading paths.
+//! Differential fuzz tests for the graphical renderer's span-reading paths.
 //!
 //! `render_snippets` reads each label's span either through a shared
 //! `SpanScanner` scan (when the source exposes its backing buffer) or through
-//! one `SourceCode::read_span` call per label. Both paths must render
-//! byte-identical reports. See the test's own doc comment for the full matrix.
+//! one `SourceCode::read_span` call per label, and a `NamedSource` carries a
+//! scan memo from one report to the next. Every combination — buffered or
+//! not, memo warm or cold — must render byte-identical reports. See each
+//! test's own doc comment for its matrix.
 
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use miette::{
     Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, MietteError,
@@ -85,6 +87,62 @@ fn render(diagnostic: &dyn Diagnostic, context_lines: usize) -> (fmt::Result, St
     (result, out)
 }
 
+/// Line-ending mixes the fuzzers sweep: LF-only, CRLF, lone-CR, and
+/// multibyte text around all three.
+const ALPHABETS: &[&[&str]] = &[
+    &["a", "\n"],
+    &["a", "b", "c", "\n"],
+    &["a", "b", "\r\n"],
+    &["a", "\r", "\n", "\r\n"],
+    &["x", "y", "\n", "é", "🦀", "\r\n"],
+];
+
+/// A random source of up to 23 segments drawn from `alpha`.
+fn random_source(rng: &mut Rng, alpha: &[&str]) -> String {
+    let n = rng.below(24);
+    let mut src = String::new();
+    for _ in 0..n {
+        src.push_str(alpha[rng.below(alpha.len())]);
+    }
+    src
+}
+
+/// 1–4 random labels over `src`, snapped to char boundaries: rendering
+/// (unlike `read_span`) slices the data as UTF-8 text.
+fn random_labels(rng: &mut Rng, src: &str, context_lines: usize) -> Vec<LabeledSpan> {
+    let floor = |mut byte: usize| {
+        byte = byte.min(src.len());
+        while byte > 0 && !src.is_char_boundary(byte) {
+            byte -= 1;
+        }
+        byte
+    };
+    (0..=rng.below(4))
+        .map(|i| {
+            // One in six labels lands just past EOF, making the whole render
+            // fail; every rendering path must agree on that too.
+            let offset =
+                if rng.below(6) == 0 { src.len() + 1 } else { floor(rng.below(src.len() + 1)) };
+            let mut len = floor(offset + [0, 1, 2, 6][rng.below(4)]).saturating_sub(offset);
+            // A zero-length span at offset 0 with zero context makes
+            // `read_span` return the window `[0, 1)` (a pre-existing quirk of
+            // its saturating span-end arithmetic), which need not be valid
+            // UTF-8 — rendering panics on every path alike. Widen such spans
+            // to the first char.
+            if context_lines == 0 && offset == 0 && len == 0 {
+                len = src.chars().next().map_or(0, char::len_utf8);
+            }
+            let label = Some(format!("label {i}"));
+            let span = (offset as u32, len as u32);
+            if rng.below(4) == 0 {
+                LabeledSpan::new_primary_with_span(label, span)
+            } else {
+                LabeledSpan::new_with_span(label, span)
+            }
+        })
+        .collect()
+}
+
 /// `render_snippets` has two ways to read spans — a shared
 /// `SpanScanner` scan when the source
 /// exposes [`SourceCode::contiguous_bytes`], and one `read_span` per
@@ -100,62 +158,13 @@ fn render(diagnostic: &dyn Diagnostic, context_lines: usize) -> (fmt::Result, St
               both paths are exercised under Miri by the normal snapshot tests"
 )]
 fn buffer_and_read_span_paths_render_identically() {
-    let alphabets: &[&[&str]] = &[
-        &["a", "\n"],
-        &["a", "b", "c", "\n"],
-        &["a", "b", "\r\n"],
-        &["a", "\r", "\n", "\r\n"],
-        &["x", "y", "\n", "é", "🦀", "\r\n"],
-    ];
     let mut rng = Rng(0x2545_F491_4F6C_DD1D);
     let mut checked = 0usize;
-    for alpha in alphabets {
+    for alpha in ALPHABETS {
         for _ in 0..300 {
-            let n = rng.below(24);
-            let mut src = String::new();
-            for _ in 0..n {
-                src.push_str(alpha[rng.below(alpha.len())]);
-            }
-            // Snap span edges to char boundaries: rendering (unlike
-            // `read_span`) slices the data as UTF-8 text.
-            let floor = |mut byte: usize| {
-                byte = byte.min(src.len());
-                while byte > 0 && !src.is_char_boundary(byte) {
-                    byte -= 1;
-                }
-                byte
-            };
+            let src = random_source(&mut rng, alpha);
             for context_lines in 0..=2 {
-                let labels: Vec<LabeledSpan> = (0..=rng.below(4))
-                    .map(|i| {
-                        // One in six labels lands just past EOF, making
-                        // the whole render fail; both paths must agree on
-                        // that too.
-                        let offset = if rng.below(6) == 0 {
-                            src.len() + 1
-                        } else {
-                            floor(rng.below(src.len() + 1))
-                        };
-                        let mut len =
-                            floor(offset + [0, 1, 2, 6][rng.below(4)]).saturating_sub(offset);
-                        // A zero-length span at offset 0 with zero
-                        // context makes `read_span` return the window
-                        // `[0, 1)` (a pre-existing quirk of its
-                        // saturating span-end arithmetic), which need not
-                        // be valid UTF-8 — rendering panics on both paths
-                        // alike. Widen such spans to the first char.
-                        if context_lines == 0 && offset == 0 && len == 0 {
-                            len = src.chars().next().map_or(0, char::len_utf8);
-                        }
-                        let label = Some(format!("label {i}"));
-                        let span = (offset as u32, len as u32);
-                        if rng.below(4) == 0 {
-                            LabeledSpan::new_primary_with_span(label, span)
-                        } else {
-                            LabeledSpan::new_with_span(label, span)
-                        }
-                    })
-                    .collect();
+                let labels = random_labels(&mut rng, &src, context_lines);
 
                 let with_buffer = TestDiag {
                     src: NamedSource::new("fuzz.rs", src.clone()),
@@ -177,4 +186,95 @@ fn buffer_and_read_span_paths_render_identically() {
         }
     }
     assert!(checked >= 4000, "expected a broad sweep, only checked {checked}");
+}
+
+/// A batch render must be indistinguishable from per-report renders.
+/// [`GraphicalReportHandler::render_reports`] shares one line scan across
+/// consecutive reports over the same backing buffer; whatever the sharing
+/// state, each yielded report must be byte-identical to a standalone
+/// [`GraphicalReportHandler::render_report`] of the same diagnostic — across
+/// LF / CRLF / lone-CR and multibyte sources, spans in any order (backwards
+/// ones fall off the memoized path), sources switching mid-batch (which
+/// resets the sharing), diagnostics with no source at all, and labels past
+/// EOF (both renders must fail identically).
+#[test]
+#[cfg_attr(
+    miri,
+    ignore = "renders thousands of graphical diagnostics to differentially fuzz two safe \
+              code paths — Miri finds no UB here and interpreting the renders is far too slow; \
+              the batched path is exercised under Miri by \
+              `batch_shares_scan_across_reports`"
+)]
+fn batched_renders_match_sequential_renders() {
+    let mut rng = Rng(0x6C62_272E_07BB_0142);
+    for alpha in ALPHABETS {
+        for _ in 0..150 {
+            let src = random_source(&mut rng, alpha);
+            let other_src = random_source(&mut rng, alpha);
+            let context_lines = rng.below(3);
+            let shared = Arc::new(NamedSource::new("fuzz.rs", src.clone()));
+
+            let count = 2 + rng.below(3);
+            let mut diagnostics: Vec<TestDiag<Arc<NamedSource<String>>>> =
+                std::iter::repeat_with(|| TestDiag {
+                    src: Arc::clone(&shared),
+                    labels: random_labels(&mut rng, &src, context_lines),
+                })
+                .take(count)
+                .collect();
+            // Sometimes switch buffers mid-batch, which must reset the
+            // sharing rather than resume the wrong source's scan.
+            let interloper = TestDiag {
+                src: Arc::new(NamedSource::new("other.rs", other_src.clone())),
+                labels: random_labels(&mut rng, &other_src, context_lines),
+            };
+            if rng.below(2) == 0 {
+                let at = rng.below(diagnostics.len());
+                diagnostics.insert(at, interloper);
+            }
+
+            let refs: Vec<&dyn Diagnostic> =
+                diagnostics.iter().map(|d| d as &dyn Diagnostic).collect();
+            let handler = GraphicalReportHandler::new_themed(GraphicalTheme::none())
+                .with_context_lines(context_lines);
+            let batched: Vec<(fmt::Result, String)> = handler.render_reports(&refs).collect();
+            for (diagnostic, batched) in refs.iter().zip(&batched) {
+                let mut out = String::new();
+                let result = handler.render_report(&mut out, *diagnostic);
+                assert_eq!(
+                    (result, &out),
+                    (batched.0, &batched.1),
+                    "diverged for src={src:?} context_lines={context_lines}"
+                );
+            }
+        }
+    }
+}
+
+/// Three ascending reports and one backwards report over a shared source:
+/// each batch item resumes (or falls off) the shared scan and must match its
+/// standalone render. Small deterministic twin of
+/// `batched_renders_match_sequential_renders` that also runs under Miri.
+#[test]
+fn batch_shares_scan_across_reports() {
+    let src = "zero\none\ntwo\nthree\nfour\nfive\n";
+    let shared = Arc::new(NamedSource::new("shared.rs", src.to_string()));
+    let diagnostics: Vec<TestDiag<Arc<NamedSource<String>>>> =
+        [(5u32, 3u32), (13, 5), (24, 4), (9, 3)]
+            .into_iter()
+            .map(|span| TestDiag {
+                src: Arc::clone(&shared),
+                labels: vec![LabeledSpan::new_with_span(Some("here".into()), span)],
+            })
+            .collect();
+    let refs: Vec<&dyn Diagnostic> = diagnostics.iter().map(|d| d as &dyn Diagnostic).collect();
+
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::none()).with_context_lines(1);
+    for (diagnostic, (batched_result, batched_out)) in
+        refs.iter().zip(handler.render_reports(&refs))
+    {
+        let mut out = String::new();
+        let result = handler.render_report(&mut out, *diagnostic);
+        assert_eq!((result, out), (batched_result, batched_out));
+    }
 }


### PR DESCRIPTION
The cache-free alternative to #289 for the same bottleneck. Both are open for comparison; they are mutually exclusive by design philosophy, not by code (this PR is standalone off main).

### Problem

Each rendered report re-scans its source from byte 0 to find the line number of its first labeled span, so a file with k diagnostics pays k full prefix scans (25.4 of cal.com.ts's 25.6 µs render is the scan; it is two memory-bandwidth SIMD passes with nothing left to trim inside one render). oxlint attaches one `Arc<NamedSource>` per file to every diagnostic of that file and renders them consecutively.

### Change

`GraphicalReportHandler::render_reports(&self, &[&dyn Diagnostic]) -> impl Iterator<Item = (fmt::Result, String)>` renders a batch while sharing the line scan: consecutive reports whose sources expose the same backing buffer (same `contiguous_bytes()` pointer + length) resume the previous report's scan. The state is a four-word `ScanSeed` carried as a **plain value** through the loop — no `Mutex`, no `SourceCode` trait hook, no `NamedSource` field, no public cache type. Buffer-pointer identity is sound here because the batch borrow keeps every source alive for the iterator's lifetime; there is no freed-and-reallocated-buffer hazard, which is exactly why the sharing lives inside one call. The iterator is lazy so callers (oxlint's minified-file fallback) can stop early.

Everything off the memoized path — the first report, out-of-order spans, non-default context width — takes today's exact scan, and the fresh scan is expressed as resume-from-the-start, so batch output is byte-identical to per-report output by construction. A `\r` in the resumed delta walks the delta break by break instead of re-scanning from byte 0, so CRLF sources share too. `render_report` is unchanged and public API is purely additive.

### Results (criterion, Apple laptop, means; 4 one-label reports at 20/40/60/80% of the file)

| fixture | sequential | batched | change |
|---|---|---|---|
| cal.com.ts (1.4 MB) | 66.0 µs | 29.2 µs | −56% |
| cal.com.tsx (1.0 MB) | 48.0 µs | 22.7 µs | −53% |
| RadixUI (2.5 KB) | 3.21 µs | 3.31 µs | +3% (nothing to amortize; the carry costs ~100 ns per batch) |

Batched cost ≈ one scan to the deepest span plus per-report rendering — the spread-out spans here are the worst case for sharing; real lint diagnostics cluster tighter and amortize further. Single-report benches (`render/*`, `render_cold`, `read_span`) measure the same work as on main.

### Correctness

Differential fuzzing at three levels, sharing the machinery proven in #289's core: `resumed_prefix_scan_matches_fresh_scan` (exhaustive over LF/CRLF/lone-CR/multibyte inputs × every memo/scan-end position, Miri-enabled), `seeded_scanner_matches_span_reader_exhaustively` (query sequences across scanner generations threading one seed, mixed context widths, stale memos), and `batched_renders_match_sequential_renders` (full batches vs standalone renders, including mid-batch source switches, sourceless diagnostics, and past-EOF labels that must fail identically), plus a deterministic Miri-enabled batch test.

### oxc adoption sketch

`DiagnosticReporter` gains a defaulted `render_errors(Vec<Error>) -> Vec<Option<String>>` (six of seven reporters untouched); `DiagnosticService::run` pre-filters (counts/`--quiet`/`--silent`), calls the batch hook, then applies its existing per-string minified-fallback/write logic; `GraphicalReporter` in `apps/oxlint/src/output_formatter/default.rs` overrides the hook with `render_reports`. The tsgolint and unused-directives paths inherit the batching through the same channel.