### PR TITLE
perf: add batch diagnostic rendering

### DIFF
--- a/benches/render.rs
+++ b/benches/render.rs
@@ -25,8 +25,8 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
 use miette::{
-    Error, GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic, NamedSource,
-    Severity, SourceCode, SourceSpan,
+    Diagnostic, Error, GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic,
+    NamedSource, Severity, SourceCode, SourceSpan,
 };
 
 /// Pinned revision of <https://github.com/oxc-project/benchmark-files>, so the
@@ -267,6 +267,68 @@ fn bench(c: &mut Criterion) {
         }
         group.finish();
     }
+
+    // Oxlint sends all diagnostics for one file together. Measure the same
+    // reports rendered independently and through a temporary source batch,
+    // including reverse input order to exercise the batch's internal source
+    // ordering and output-order restoration.
+    let mut group = c.benchmark_group("render_batch/ci");
+    let handler = ci_handler();
+    for fixture in &fixtures {
+        for (order, reverse) in [("ascending", false), ("descending", true)] {
+            let mut diagnostics: Vec<Error> = (1..=16)
+                .map(|part| {
+                    let offset = fixture.source_len * part / 17;
+                    let span = identifier_span_at(fixture.source.inner(), offset);
+                    let diagnostic = lint_diagnostic(
+                        "Variable 'resolve' is declared but never used.",
+                        "Consider removing this declaration.",
+                    )
+                    .with_label(LabeledSpan::new_with_span(
+                        Some("'resolve' is declared here".to_string()),
+                        span,
+                    ));
+                    Error::new(diagnostic).with_source_code(Arc::clone(&fixture.source))
+                })
+                .collect();
+            if reverse {
+                diagnostics.reverse();
+            }
+            let diagnostics: Vec<&dyn Diagnostic> = diagnostics.iter().map(AsRef::as_ref).collect();
+
+            group.throughput(Throughput::Bytes(fixture.source_len as u64));
+            group.bench_function(
+                BenchmarkId::new(format!("standalone/{order}"), fixture.name),
+                |b| {
+                    b.iter(|| {
+                        diagnostics
+                            .iter()
+                            .map(|diagnostic| {
+                                let mut out = String::new();
+                                handler
+                                    .render_report(&mut out, black_box(*diagnostic))
+                                    .expect("render succeeds");
+                                out
+                            })
+                            .collect::<Vec<_>>()
+                    });
+                },
+            );
+            group.bench_function(BenchmarkId::new(format!("batched/{order}"), fixture.name), |b| {
+                b.iter(|| {
+                    handler
+                        .render_reports(fixture.source.as_ref(), black_box(&diagnostics))
+                        .into_iter()
+                        .map(|(result, rendered)| {
+                            result.expect("render succeeds");
+                            rendered
+                        })
+                        .collect::<Vec<_>>()
+                });
+            });
+        }
+    }
+    group.finish();
 }
 
 criterion_group!(

--- a/src/handlers/graphical/mod.rs
+++ b/src/handlers/graphical/mod.rs
@@ -26,6 +26,7 @@ mod span;
 use std::fmt;
 
 pub use handler::GraphicalReportHandler;
+pub use report::GraphicalReportBatch;
 
 use crate::{Diagnostic, ReportHandler};
 

--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -12,10 +12,129 @@ use std::fmt::{self, Write};
 
 use owo_colors::OwoColorize;
 
-use super::handler::{GraphicalReportHandler, LinkStyle};
-use crate::{Diagnostic, Severity, SourceCode};
+use super::{
+    handler::{GraphicalReportHandler, LinkStyle},
+    snippet::SnippetState,
+};
+use crate::{Diagnostic, Labels, Severity, SourceCode, source_impls::ScanSeed};
+
+/// A temporary graphical rendering session for diagnostics over one source.
+///
+/// When available, the batch snapshots the source's current contiguous buffer
+/// once and carries only compact prefix-scan state between reports. It owns no
+/// source data and stores no state in the source.
+pub struct GraphicalReportBatch<'handler, 'source> {
+    handler: &'handler GraphicalReportHandler,
+    source: &'source dyn SourceCode,
+    source_name: Option<&'source str>,
+    source_bytes: Option<&'source [u8]>,
+    resume: Option<ScanSeed>,
+}
+
+impl GraphicalReportBatch<'_, '_> {
+    /// Render one diagnostic using this batch's source.
+    ///
+    /// The batch source is authoritative for the top-level diagnostic.
+    /// Related diagnostics that provide their own source use that source;
+    /// source-less related diagnostics inherit the batch source.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing the rendered report fails or a labeled
+    /// span cannot be read from the batch source.
+    pub fn render_report(
+        &mut self,
+        f: &mut impl fmt::Write,
+        diagnostic: &dyn Diagnostic,
+    ) -> fmt::Result {
+        self.render_report_inner(f, diagnostic, None)
+    }
+
+    fn render_report_inner(
+        &mut self,
+        f: &mut impl fmt::Write,
+        diagnostic: &dyn Diagnostic,
+        labels: Option<Labels>,
+    ) -> fmt::Result {
+        let mut snippets = SnippetState::resumed(
+            self.source,
+            self.source_name,
+            self.source_bytes,
+            self.handler.context_lines,
+            self.handler.context_lines,
+            self.resume,
+        );
+        let result =
+            self.handler.render_report_with_state(f, diagnostic, Some(&mut snippets), labels);
+        self.resume = snippets.memo().or(self.resume);
+        result
+    }
+}
 
 impl GraphicalReportHandler {
+    /// Begin rendering a batch of diagnostics over `source`.
+    ///
+    /// When the source exposes a contiguous buffer, the returned batch borrows
+    /// that current buffer once. Reports rendered in source order resume their
+    /// prefix scan from the preceding report. A backwards jump remains correct
+    /// but starts its prefix scan over. Dropping the batch discards the compact
+    /// scan state; a later batch observes the source again from scratch.
+    pub fn begin_batch<'handler, 'source>(
+        &'handler self,
+        source: &'source dyn SourceCode,
+    ) -> GraphicalReportBatch<'handler, 'source> {
+        GraphicalReportBatch {
+            handler: self,
+            source,
+            source_name: source.name(),
+            source_bytes: source.contiguous_bytes(),
+            resume: None,
+        }
+    }
+
+    /// Render diagnostics over one source as a batch.
+    ///
+    /// Diagnostics are scanned in source order for performance and returned in
+    /// the caller's original order. When available, the batch borrows the
+    /// source's current contiguous buffer once, so mutable [`SourceCode`]
+    /// implementations produce one coherent render without any state cached
+    /// beyond this call. Sources without a contiguous buffer use their
+    /// ordinary [`SourceCode::read_span`] implementation for every span.
+    ///
+    /// The supplied source is authoritative for every top-level diagnostic.
+    /// Related diagnostics may still provide their own source.
+    pub fn render_reports(
+        &self,
+        source: &dyn SourceCode,
+        diagnostics: &[&dyn Diagnostic],
+    ) -> Vec<(fmt::Result, String)> {
+        let mut order: Vec<_> = diagnostics
+            .iter()
+            .enumerate()
+            .map(|(index, &diagnostic)| {
+                let labels = diagnostic.labels();
+                let offset = labels
+                    .as_slice()
+                    .iter()
+                    .map(crate::LabeledSpan::offset)
+                    .min()
+                    .unwrap_or(u32::MAX);
+                (offset, index, diagnostic, labels)
+            })
+            .collect();
+        order.sort_unstable_by_key(|&(offset, ..)| offset);
+
+        let mut reports: Vec<Option<(fmt::Result, String)>> = Vec::with_capacity(diagnostics.len());
+        reports.resize_with(diagnostics.len(), || None);
+        let mut batch = self.begin_batch(source);
+        for (_, index, diagnostic, labels) in order {
+            let mut rendered = String::new();
+            let result = batch.render_report_inner(&mut rendered, diagnostic, Some(labels));
+            reports[index] = Some((result, rendered));
+        }
+        reports.into_iter().flatten().collect()
+    }
+
     /// Render a [`Diagnostic`]. This function is mostly internal and meant to
     /// be called by the toplevel [`ReportHandler`](crate::ReportHandler)
     /// handler, but is made public to make it easier (possible) to test in
@@ -29,12 +148,29 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
     ) -> fmt::Result {
+        let mut snippets = diagnostic
+            .source_code()
+            .map(|source| SnippetState::new(source, self.context_lines, self.context_lines));
+        self.render_report_with_state(f, diagnostic, snippets.as_mut(), None)
+    }
+
+    fn render_report_with_state(
+        &self,
+        f: &mut impl fmt::Write,
+        diagnostic: &dyn Diagnostic,
+        mut snippets: Option<&mut SnippetState<'_>>,
+        labels: Option<Labels>,
+    ) -> fmt::Result {
         writeln!(f)?;
         self.render_causes(f, diagnostic)?;
-        let src = diagnostic.source_code();
-        self.render_snippets(f, diagnostic, src)?;
+        if let Some(state) = snippets.as_deref_mut() {
+            match labels {
+                Some(labels) => self.render_snippets_with_labels(f, labels, state)?,
+                None => self.render_snippets_with(f, diagnostic, state)?,
+            }
+        }
         self.render_footer(f, diagnostic)?;
-        self.render_related(f, diagnostic, src)?;
+        self.render_related(f, diagnostic, snippets)?;
         if let Some(footer) = &self.footer {
             writeln!(f)?;
             let width = self.termwidth.saturating_sub(4);
@@ -173,7 +309,7 @@ impl GraphicalReportHandler {
         &self,
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
-        parent_src: Option<&dyn SourceCode>,
+        mut inherited: Option<&mut SnippetState<'_>>,
     ) -> fmt::Result {
         let related = diagnostic.related();
         if !related.is_empty() {
@@ -187,10 +323,20 @@ impl GraphicalReportHandler {
                 }
                 inner_renderer.render_header(f, rel)?;
                 inner_renderer.render_causes(f, rel)?;
-                let src = rel.source_code().or(parent_src);
-                inner_renderer.render_snippets(f, rel, src)?;
-                inner_renderer.render_footer(f, rel)?;
-                inner_renderer.render_related(f, rel, src)?;
+                if let Some(source) = rel.source_code() {
+                    let mut snippets =
+                        SnippetState::new(source, self.context_lines, self.context_lines);
+                    inner_renderer.render_snippets_with(f, rel, &mut snippets)?;
+                    inner_renderer.render_footer(f, rel)?;
+                    inner_renderer.render_related(f, rel, Some(&mut snippets))?;
+                } else if let Some(snippets) = inherited.as_deref_mut() {
+                    inner_renderer.render_snippets_with(f, rel, snippets)?;
+                    inner_renderer.render_footer(f, rel)?;
+                    inner_renderer.render_related(f, rel, Some(snippets))?;
+                } else {
+                    inner_renderer.render_footer(f, rel)?;
+                    inner_renderer.render_related(f, rel, None)?;
+                }
             }
         }
         Ok(())

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -18,35 +18,66 @@ use super::{
     span::{FancySpan, LabelRenderMode},
 };
 use crate::{
-    Diagnostic, LabeledSpan, MietteSpanContents, SourceCode, SourceSpan, SpanContents,
-    source_impls::SpanScanner,
+    Diagnostic, LabeledSpan, Labels, MietteError, MietteSpanContents, SourceCode, SourceSpan,
+    SpanContents,
+    source_impls::{ScanSeed, SpanScanner},
 };
 
-impl GraphicalReportHandler {
-    pub(super) fn render_snippets(
-        &self,
-        f: &mut impl fmt::Write,
-        diagnostic: &dyn Diagnostic,
-        opt_source: Option<&dyn SourceCode>,
-    ) -> fmt::Result {
-        let Some(source) = opt_source else { return Ok(()) };
-        let mut labels = diagnostic.labels();
-        if labels.is_empty() {
-            return Ok(());
-        }
-        labels.sort_unstable_by_key(|l| l.inner().offset());
+/// Span-reading state shared by one or more rendered diagnostics.
+pub(super) struct SnippetState<'source> {
+    source: &'source dyn SourceCode,
+    source_name: Option<&'source str>,
+    scanner: Option<SpanScanner<'source>>,
+}
 
-        // When the source exposes its backing buffer, share one forward scan
-        // across every span lookup below (one per label plus one per merge
-        // attempt); each `read_span` otherwise scans the source from byte 0
-        // again. The scanner bypasses the source's own `read_span`, so
-        // re-attach the source's name the way `NamedSource` would.
-        let mut scanner = source
-            .contiguous_bytes()
-            .map(|bytes| SpanScanner::new(bytes, self.context_lines, self.context_lines));
-        let source_name = source.name();
-        let mut read = |span: &SourceSpan| match scanner.as_mut() {
-            Some(scanner) => scanner.read_span(*span).map(|contents| match source_name {
+impl<'source> SnippetState<'source> {
+    /// State for one independent report. The scanner keeps only the leading
+    /// context around its first query, minimizing temporary memory.
+    pub(super) fn new(
+        source: &'source dyn SourceCode,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Self {
+        Self {
+            source,
+            source_name: source.name(),
+            scanner: source.contiguous_bytes().map(|bytes| {
+                SpanScanner::new(bytes, context_lines_before, context_lines_after, None)
+            }),
+        }
+    }
+
+    /// State for one report in a batch, using the source metadata and
+    /// contiguous buffer captured when the batch began.
+    pub(super) fn resumed(
+        source: &'source dyn SourceCode,
+        source_name: Option<&'source str>,
+        source_bytes: Option<&'source [u8]>,
+        context_lines_before: usize,
+        context_lines_after: usize,
+        resume: Option<ScanSeed>,
+    ) -> Self {
+        Self {
+            source,
+            source_name,
+            scanner: source_bytes.map(|bytes| {
+                SpanScanner::new(bytes, context_lines_before, context_lines_after, resume)
+            }),
+        }
+    }
+
+    pub(super) fn memo(&self) -> Option<ScanSeed> {
+        self.scanner.as_ref().and_then(SpanScanner::memo)
+    }
+
+    fn read_span(
+        &mut self,
+        span: SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<MietteSpanContents<'source>, MietteError> {
+        match self.scanner.as_mut() {
+            Some(scanner) => scanner.read_span(span).map(|contents| match self.source_name {
                 Some(name) => MietteSpanContents::new_named(
                     Cow::Borrowed(name),
                     contents.data(),
@@ -57,17 +88,44 @@ impl GraphicalReportHandler {
                 ),
                 None => contents,
             }),
-            None => source.read_span(span, self.context_lines, self.context_lines),
-        };
+            None => self.source.read_span(&span, context_lines_before, context_lines_after),
+        }
+    }
+}
+
+impl GraphicalReportHandler {
+    pub(super) fn render_snippets_with(
+        &self,
+        f: &mut impl fmt::Write,
+        diagnostic: &dyn Diagnostic,
+        state: &mut SnippetState<'_>,
+    ) -> fmt::Result {
+        self.render_snippets_with_labels(f, diagnostic.labels(), state)
+    }
+
+    pub(super) fn render_snippets_with_labels(
+        &self,
+        f: &mut impl fmt::Write,
+        mut labels: Labels,
+        state: &mut SnippetState<'_>,
+    ) -> fmt::Result {
+        if labels.is_empty() {
+            return Ok(());
+        }
+        labels.sort_unstable_by_key(|l| l.inner().offset());
 
         if let [label] = labels.as_slice() {
-            let contents = read(label.inner()).map_err(|_| fmt::Error)?;
+            let contents = state
+                .read_span(*label.inner(), self.context_lines, self.context_lines)
+                .map_err(|_| fmt::Error)?;
             return self.render_context(f, label, &contents, &labels);
         }
 
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
         for right in &labels {
-            let right_conts = read(right.inner()).map_err(|_| fmt::Error)?;
+            let right_conts = state
+                .read_span(*right.inner(), self.context_lines, self.context_lines)
+                .map_err(|_| fmt::Error)?;
 
             if contexts.is_empty() {
                 contexts.push((Cow::Borrowed(right), right_conts));
@@ -87,7 +145,9 @@ impl GraphicalReportHandler {
                     new_end - left.offset(),
                 );
                 // Check that the two contexts can be combined
-                if let Ok(new_conts) = read(new_span.inner()) {
+                if let Ok(new_conts) =
+                    state.read_span(*new_span.inner(), self.context_lines, self.context_lines)
+                {
                     contexts.pop();
                     contexts.push((Cow::Owned(new_span), new_conts));
                     continue;

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -199,6 +199,45 @@ impl LeadingContext {
     }
 }
 
+/// Whether `pos` sits between the `\r` and `\n` of a CRLF pair.
+fn splits_crlf_pair(input: &[u8], pos: usize) -> bool {
+    pos > 0 && input[pos - 1] == b'\r' && input.get(pos) == Some(&b'\n')
+}
+
+/// Bulk newline count. Miri cannot interpret bytecount's architecture-specific
+/// SIMD implementation, so it uses the equivalent bytewise count.
+#[expect(
+    clippy::naive_bytecount,
+    reason = "the naive branch exists because bytecount is uninterpretable under Miri"
+)]
+fn count_newlines(haystack: &[u8]) -> usize {
+    if cfg!(miri) {
+        haystack.iter().filter(|&&byte| byte == b'\n').count()
+    } else {
+        bytecount::count(haystack, b'\n')
+    }
+}
+
+/// Compact state describing a completed source-prefix scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(clippy::redundant_pub_crate, reason = "keeps the scan seed crate-private")]
+pub(crate) struct ScanSeed {
+    pos: usize,
+    line_count: usize,
+    previous_line_start: Option<usize>,
+    current_line_start: usize,
+}
+
+impl ScanSeed {
+    const START: Self =
+        Self { pos: 0, line_count: 0, previous_line_start: None, current_line_start: 0 };
+
+    #[cfg(all(test, feature = "fancy-base"))]
+    pub(crate) fn pos(&self) -> usize {
+        self.pos
+    }
+}
+
 /// State produced by scanning the source prefix before a span.
 struct PrefixScan {
     line_count: usize,
@@ -209,10 +248,10 @@ struct PrefixScan {
 impl PrefixScan {
     /// Scan the prefix before a span, retaining only its leading context lines.
     #[inline]
-    fn new(input: &[u8], end: usize, context_lines_before: usize) -> Self {
+    fn new(input: &[u8], end: usize, context_lines_before: usize, seed: Option<ScanSeed>) -> Self {
         let prefix = &input[..end];
         if context_lines_before == 1 {
-            return Self::one_context_line(prefix);
+            return Self::one_context_line_resumed(prefix, seed.unwrap_or(ScanSeed::START));
         }
 
         let mut scan = Self {
@@ -230,25 +269,34 @@ impl PrefixScan {
 
     /// The graphical handler's default. Keep the one retained line start in a
     /// scalar while scanning instead of updating a `VecDeque` for every line.
-    fn one_context_line(prefix: &[u8]) -> Self {
-        let mut line_count = 0;
-        let mut current_line_start = 0;
-        let mut previous_line_start = None;
+    fn one_context_line_resumed(prefix: &[u8], seed: ScanSeed) -> Self {
+        let seed = if seed.pos <= prefix.len() { seed } else { ScanSeed::START };
+        debug_assert!(!splits_crlf_pair(prefix, seed.pos));
+        let delta = &prefix[seed.pos..];
 
-        if memchr::memchr(b'\r', prefix).is_none() {
-            // Most source files only use LF. Count all breaks in one SIMD pass,
-            // then recover the two line starts the caller needs from the end.
-            line_count = bytecount::count(prefix, b'\n');
-            if let Some(last_break) = memchr::memrchr(b'\n', prefix) {
-                current_line_start = last_break + 1;
-                previous_line_start =
-                    Some(memchr::memrchr(b'\n', &prefix[..last_break]).map_or(0, |pos| pos + 1));
-            }
-        } else {
-            for line_break in LineBreaks::new(prefix) {
+        let mut line_count = seed.line_count;
+        let mut previous_line_start = seed.previous_line_start;
+        let mut current_line_start = seed.current_line_start;
+        if memchr::memchr(b'\r', delta).is_some() {
+            for line_break in LineBreaks::new(delta) {
                 line_count += 1;
                 previous_line_start = Some(current_line_start);
-                current_line_start = line_break.next_line_start();
+                current_line_start = seed.pos + line_break.next_line_start();
+            }
+        } else {
+            let breaks = count_newlines(delta);
+            if breaks > 0 {
+                let last_break =
+                    memchr::memrchr(b'\n', delta).expect("delta contains counted breaks");
+                previous_line_start = Some(if breaks == 1 {
+                    seed.current_line_start
+                } else {
+                    let second_to_last = memchr::memrchr(b'\n', &delta[..last_break])
+                        .expect("delta contains counted breaks");
+                    seed.pos + second_to_last + 1
+                });
+                current_line_start = seed.pos + last_break + 1;
+                line_count += breaks;
             }
         }
 
@@ -302,7 +350,7 @@ impl<'a> SpanReader<'a> {
     fn new(input: &'a [u8], request: SpanRequest, context: ContextLines) -> Self {
         let offset = request.prefix_end(input);
         let PrefixScan { line_count, leading, current_line_start } =
-            PrefixScan::new(input, offset, context.before);
+            PrefixScan::new(input, offset, context.before, None);
         Self {
             input,
             request,
@@ -468,15 +516,38 @@ impl<'a> LineIndex<'a> {
 
     /// First query: retain the line starts in its leading context window and
     /// use them as the origin of the reusable index.
-    fn init(&mut self, cut: usize, context_lines_before: usize) {
+    fn init(&mut self, cut: usize, context_lines_before: usize, seed: Option<ScanSeed>) {
         let PrefixScan { line_count, leading, current_line_start } =
-            PrefixScan::new(self.input, cut, context_lines_before);
+            PrefixScan::new(self.input, cut, context_lines_before, seed);
         debug_assert_eq!(leading.start_line + leading.len(), line_count);
         self.base_line = leading.start_line;
         self.line_starts.reserve(leading.len() + 8);
         leading.append_to(&mut self.line_starts);
         self.line_starts.push(current_line_start);
         self.frontier = cut;
+    }
+
+    /// The scan state at `frontier`, for memoization by [`ScanSeed`].
+    fn seed(&self) -> Option<ScanSeed> {
+        debug_assert!(
+            !splits_crlf_pair(self.input, self.frontier),
+            "the frontier never splits a CRLF pair"
+        );
+        match self.line_starts.as_slice() {
+            [.., previous, current] => Some(ScanSeed {
+                pos: self.frontier,
+                line_count: self.base_line + self.line_starts.len() - 1,
+                previous_line_start: Some(*previous),
+                current_line_start: *current,
+            }),
+            [start] if self.base_line == 0 => Some(ScanSeed {
+                pos: self.frontier,
+                line_count: 0,
+                previous_line_start: None,
+                current_line_start: *start,
+            }),
+            _ => None,
+        }
     }
 
     /// Extend the index so every break in `[0, target)` is recorded, with one
@@ -692,6 +763,11 @@ impl<'index, 'source> IndexedReader<'index, 'source> {
 pub(crate) struct SpanScanner<'a> {
     context: ContextLines,
     index: LineIndex<'a>,
+    /// State memoized by an earlier scanner over the same bytes, consumed by
+    /// the first query's prefix scan.
+    resume: Option<ScanSeed>,
+    /// This scanner's state at its first query's prefix cut.
+    memo: Option<ScanSeed>,
 }
 
 #[cfg(feature = "fancy-base")]
@@ -700,11 +776,20 @@ impl<'a> SpanScanner<'a> {
         input: &'a [u8],
         context_lines_before: usize,
         context_lines_after: usize,
+        resume: Option<ScanSeed>,
     ) -> Self {
         Self {
             context: ContextLines::new(context_lines_before, context_lines_after),
             index: LineIndex::new(input),
+            resume,
+            memo: None,
         }
+    }
+
+    /// The state of this scanner's first prefix scan, suitable for resuming
+    /// another scanner over the same bytes.
+    pub(crate) fn memo(&self) -> Option<ScanSeed> {
+        self.memo
     }
 
     /// Read a span while scanning only source bytes no earlier query scanned.
@@ -715,7 +800,9 @@ impl<'a> SpanScanner<'a> {
         let request = SpanRequest::new(span);
         let cut = request.prefix_end(self.index.input);
         if self.index.is_empty() {
-            self.index.init(cut, self.context.before);
+            let seed = if self.context.before == 1 { self.resume.take() } else { None };
+            self.index.init(cut, self.context.before, seed);
+            self.memo = self.index.seed();
         } else {
             if cut < self.index.origin().expect("a non-empty index has an origin") {
                 return self.read_unindexed(request);
@@ -892,12 +979,49 @@ mod tests {
     fn lf_prefix_fast_path_matches_generic_path() {
         let input = b"zero\none\n\ntwo\nthree\n";
         for cut in 0..=input.len() {
-            let fast = PrefixScan::new(input, cut, 1);
-            let generic = PrefixScan::new(input, cut, 2);
+            let fast = PrefixScan::new(input, cut, 1, None);
+            let generic = PrefixScan::new(input, cut, 2, None);
             assert_eq!(fast.line_count, generic.line_count, "cut={cut}");
             assert_eq!(fast.current_line_start, generic.current_line_start, "cut={cut}");
             assert_eq!(fast.leading.first(), generic.leading.last(), "cut={cut}");
             assert_eq!(fast.leading.start_line, fast.line_count.saturating_sub(1), "cut={cut}");
+        }
+    }
+
+    #[test]
+    fn resumed_prefix_scan_matches_fresh_scan() {
+        let inputs: &[&[u8]] = &[
+            b"",
+            b"a",
+            b"zero\none\n\ntwo\nthree\n",
+            b"a\r\nb\r\nc",
+            b"a\rb\rc",
+            b"mixed\r\nlf\nlone\rend",
+            b"\r\n\r\n",
+            "caf\u{e9}\nn\u{1f402}ext\n".as_bytes(),
+        ];
+        for &input in inputs {
+            for mid in 0..=input.len() {
+                if splits_crlf_pair(input, mid) {
+                    continue;
+                }
+                let at_mid = PrefixScan::new(input, mid, 1, None);
+                let seed = ScanSeed {
+                    pos: mid,
+                    line_count: at_mid.line_count,
+                    previous_line_start: at_mid.leading.last(),
+                    current_line_start: at_mid.current_line_start,
+                };
+                for cut in mid..=input.len() {
+                    let context = format!("input={input:?} mid={mid} cut={cut}");
+                    let resumed = PrefixScan::new(input, cut, 1, Some(seed));
+                    let fresh = PrefixScan::new(input, cut, 1, None);
+                    assert_eq!(resumed.line_count, fresh.line_count, "{context}");
+                    assert_eq!(resumed.current_line_start, fresh.current_line_start, "{context}");
+                    assert_eq!(resumed.leading.start_line, fresh.leading.start_line, "{context}");
+                    assert_eq!(resumed.leading.first(), fresh.leading.first(), "{context}");
+                }
+            }
         }
     }
 
@@ -1199,7 +1323,7 @@ mod scanner_tests {
 
                     // Random order: queries may jump backwards past the
                     // index origin.
-                    let mut scanner = SpanScanner::new(input, before, after);
+                    let mut scanner = SpanScanner::new(input, before, after, None);
                     for i in 0..spans.len() {
                         check(&mut scanner, input, spans[i], before, after, &spans[..i]);
                         checked += 1;
@@ -1212,7 +1336,7 @@ mod scanner_tests {
                     let first = spans[0].0;
                     let merged_end = spans.iter().map(|&(o, l)| o + l).max().unwrap();
                     spans.push((first, merged_end - first));
-                    let mut scanner = SpanScanner::new(input, before, after);
+                    let mut scanner = SpanScanner::new(input, before, after, None);
                     for i in 0..spans.len() {
                         check(&mut scanner, input, spans[i], before, after, &spans[..i]);
                         checked += 1;
@@ -1223,14 +1347,44 @@ mod scanner_tests {
         assert!(checked > 100_000, "expected a broad sweep, only checked {checked}");
     }
 
+    #[test]
+    fn seeded_scanner_matches_span_reader() {
+        let inputs: &[&[u8]] =
+            &[b"a\nb\nc\nd\n", b"a\r\nb\r\nc\r\n", b"a\rb\rc\rd", "a\né\r\n🦀\rend\n".as_bytes()];
+        let spans = [(2, 1), (4, 1), (6, 1), (1, 0)];
+        for &input in inputs {
+            let mut seed = None;
+            for (generation, span) in spans.into_iter().enumerate() {
+                let mut scanner = SpanScanner::new(input, 1, 1, seed);
+                check(&mut scanner, input, span, 1, 1, &spans[..generation]);
+                seed = scanner.memo().or(seed);
+            }
+        }
+    }
+
+    #[test]
+    fn memo_records_the_first_querys_cut() {
+        let input = b"a\nb\nc\nd\n";
+
+        let mut scanner = SpanScanner::new(input, 1, 1, None);
+        assert!(scanner.memo().is_none());
+        scanner.read_span((6, 1).into()).unwrap();
+        let memo = scanner.memo().expect("the first query memoizes its scan");
+        assert_eq!(memo.pos(), 5);
+
+        let mut scanner = SpanScanner::new(input, 1, 1, Some(memo));
+        check(&mut scanner, input, (2, 1), 1, 1, &[]);
+        assert_eq!(scanner.memo().expect("the earlier query replaces the memo").pos(), 1);
+    }
+
     /// The empty-source and just-past-EOF edge cases `SpanReader` special
     /// cases, issued through one scanner.
     #[test]
     fn zero_length_spans_at_eof() {
-        let mut scanner = SpanScanner::new(b"", 0, 0);
+        let mut scanner = SpanScanner::new(b"", 0, 0, None);
         check(&mut scanner, b"", (0, 0), 0, 0, &[]);
         check(&mut scanner, b"", (1, 0), 0, 0, &[(0, 0)]);
-        let mut scanner = SpanScanner::new(b"a", 1, 1);
+        let mut scanner = SpanScanner::new(b"a", 1, 1, None);
         check(&mut scanner, b"a", (1, 0), 1, 1, &[]);
         check(&mut scanner, b"a", (2, 0), 1, 1, &[(1, 0)]);
     }

--- a/tests/single_scan.rs
+++ b/tests/single_scan.rs
@@ -10,7 +10,13 @@
 //! one `SourceCode::read_span` call per label. Both paths must render
 //! byte-identical reports. See the test's own doc comment for the full matrix.
 
-use std::fmt;
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use miette::{
     Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, MietteError,
@@ -177,4 +183,105 @@ fn buffer_and_read_span_paths_render_identically() {
         }
     }
     assert!(checked >= 4000, "expected a broad sweep, only checked {checked}");
+}
+
+#[test]
+fn batch_matches_standalone_renders_in_any_order() {
+    let source =
+        Arc::new(NamedSource::new("shared.rs", "zero\none\ntwo\nthree\nfour\nfive\n".to_string()));
+    let diagnostics: Vec<TestDiag<Arc<NamedSource<String>>>> =
+        [(24u32, 4u32), (5, 3), (19, 4), (9, 3)]
+            .into_iter()
+            .map(|span| TestDiag {
+                src: Arc::clone(&source),
+                labels: vec![LabeledSpan::new_with_span(Some("here".into()), span)],
+            })
+            .collect();
+
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::none());
+    let diagnostic_refs: Vec<&dyn Diagnostic> =
+        diagnostics.iter().map(|diagnostic| diagnostic as &dyn Diagnostic).collect();
+    let batched = handler.render_reports(source.as_ref(), &diagnostic_refs);
+    for (diagnostic, batched) in diagnostics.iter().zip(batched) {
+        let mut standalone = String::new();
+        let standalone_result = handler.render_report(&mut standalone, diagnostic);
+        assert_eq!(batched, (standalone_result, standalone));
+    }
+}
+
+#[derive(Debug)]
+struct SwitchingSource {
+    second: AtomicBool,
+}
+
+impl SwitchingSource {
+    const FIRST: &'static str = "zero\nfirst\nend\n";
+    const SECOND: &'static str = "zero\nsecond\nend\n";
+
+    fn current(&self) -> &'static str {
+        if self.second.load(Ordering::Relaxed) { Self::SECOND } else { Self::FIRST }
+    }
+}
+
+impl SourceCode for SwitchingSource {
+    fn read_span<'a>(
+        &'a self,
+        span: &SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<MietteSpanContents<'a>, MietteError> {
+        self.current().read_span(span, context_lines_before, context_lines_after)
+    }
+
+    fn name(&self) -> Option<&str> {
+        Some("switch.rs")
+    }
+
+    fn contiguous_bytes(&self) -> Option<&[u8]> {
+        Some(self.current().as_bytes())
+    }
+}
+
+#[derive(Debug)]
+struct SourceLessDiag {
+    labels: Vec<LabeledSpan>,
+}
+
+impl fmt::Display for SourceLessDiag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("test diagnostic")
+    }
+}
+
+impl std::error::Error for SourceLessDiag {}
+
+impl Diagnostic for SourceLessDiag {
+    fn labels(&self) -> Labels {
+        Labels::Many(self.labels.clone())
+    }
+}
+
+#[test]
+fn a_new_batch_observes_a_mutable_sources_current_buffer() {
+    let source = SwitchingSource { second: AtomicBool::new(false) };
+    let diagnostic =
+        SourceLessDiag { labels: vec![LabeledSpan::new_with_span(Some("here".into()), (5, 1))] };
+    let handler = GraphicalReportHandler::new_themed(GraphicalTheme::none());
+
+    {
+        let mut first_batch = handler.begin_batch(&source);
+        let mut first = String::new();
+        first_batch.render_report(&mut first, &diagnostic).unwrap();
+        assert!(first.contains("first"));
+
+        source.second.store(true, Ordering::Relaxed);
+        let mut same_batch = String::new();
+        first_batch.render_report(&mut same_batch, &diagnostic).unwrap();
+        assert!(same_batch.contains("first"), "a batch renders one coherent source snapshot");
+    }
+
+    let mut second_batch = handler.begin_batch(&source);
+    let mut second = String::new();
+    second_batch.render_report(&mut second, &diagnostic).unwrap();
+    assert!(second.contains("second"), "a later batch must not reuse stale scan state");
 }


### PR DESCRIPTION
## Summary

- add a temporary graphical batch API that snapshots contiguous source buffers
- carry compact scan state between source-ordered reports without a persistent cache
- preserve caller output order and cover mutable sources, scan resumption, and batch benchmarks

This enables Oxc to avoid repeatedly scanning large source prefixes when rendering a file's diagnostics.