### PR TITLE
perf: add graphical batch rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive",
  "regex",
+ "rustc-hash",
  "rustversion",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ cfg-if = "1"
 
 bytecount = "0.6.9"
 memchr = "2"
+rustc-hash = { version = "2", optional = true }
 unicode-width = "0.2.0"
 unicode-segmentation = "1.12.0"
 
@@ -192,6 +193,7 @@ derive = ["oxc-miette-derive"]
 no-format-args-capture = []
 fancy-base = [
     "owo-colors",
+    "rustc-hash",
     "textwrap",
 ]
 fancy-no-syscall = [

--- a/benches/render.rs
+++ b/benches/render.rs
@@ -25,8 +25,8 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
 use miette::{
-    Error, GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic, NamedSource,
-    Severity, SourceCode, SourceSpan,
+    Diagnostic, Error, GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic,
+    NamedSource, Severity, SourceCode, SourceSpan,
 };
 
 /// Pinned revision of <https://github.com/oxc-project/benchmark-files>, so the
@@ -45,6 +45,8 @@ const FIXTURES: &[&str] = &[
 const SPAN_FRACTION: f64 = 0.9;
 /// Distance between the declaration and assignment labels.
 const RELATED_SPAN_DELTA: usize = 250;
+/// Number of reports sharing one source in the batch comparison.
+const BATCH_SIZE: usize = 32;
 
 struct Fixture {
     name: &'static str,
@@ -187,6 +189,32 @@ fn assigned_diagnostic(fixture: &Fixture) -> Error {
     Error::new(diagnostic).with_source_code(Arc::clone(&fixture.source))
 }
 
+/// Build reverse-ordered diagnostics spread across one shared source. This
+/// exercises the batch scanner's ability to reuse its retained prefix for
+/// arbitrary input order.
+fn batch_diagnostics(fixture: &Fixture) -> Vec<Error> {
+    (0..BATCH_SIZE)
+        .rev()
+        .map(|index| {
+            let offset = fixture.source_len * (index + 1) / (BATCH_SIZE + 1);
+            let span = identifier_span_at(fixture.source.inner(), offset);
+            let diagnostic = lint_diagnostic(
+                "Variable is declared but never used.",
+                "Consider removing this declaration.",
+            )
+            .with_label(LabeledSpan::new_with_span(
+                Some("variable is declared here".to_string()),
+                span,
+            ));
+            Error::new(diagnostic).with_source_code(Arc::clone(&fixture.source))
+        })
+        .collect()
+}
+
+fn as_diagnostic(error: &Error) -> &dyn Diagnostic {
+    error.as_ref()
+}
+
 /// Add the rule metadata that `LintContext` attaches to every oxlint diagnostic.
 fn lint_diagnostic(message: &str, help: &str) -> MietteDiagnostic {
     MietteDiagnostic::new(message)
@@ -264,6 +292,57 @@ fn bench(c: &mut Criterion) {
                     });
                 });
             }
+        }
+        group.finish();
+    }
+
+    // Compare the existing one-scanner-per-report mechanism with batch-local
+    // indexing. Inputs are deliberately reverse ordered; both paths must emit
+    // the reports in that same order, while the batch scans each source prefix
+    // only once.
+    for (mode, handler) in [("terminal", terminal_handler()), ("ci", ci_handler())] {
+        let mut group = c.benchmark_group(format!("render_batch/{mode}"));
+        group.throughput(Throughput::Elements(BATCH_SIZE as u64));
+        for fixture in &fixtures {
+            let diagnostics = batch_diagnostics(fixture);
+
+            let mut individual_output = String::new();
+            for diagnostic in &diagnostics {
+                handler
+                    .render_report(&mut individual_output, as_diagnostic(diagnostic))
+                    .expect("render succeeds");
+            }
+            let mut batch_output = String::new();
+            handler
+                .render_reports(&mut batch_output, diagnostics.iter().map(as_diagnostic))
+                .expect("batch render succeeds");
+            assert_eq!(individual_output, batch_output);
+
+            group.bench_function(BenchmarkId::new("individual", fixture.name), |b| {
+                b.iter(|| {
+                    let mut output = String::new();
+                    for diagnostic in &diagnostics {
+                        handler
+                            .render_report(&mut output, black_box(as_diagnostic(diagnostic)))
+                            .expect("render succeeds");
+                    }
+                    black_box(output);
+                });
+            });
+            group.bench_function(BenchmarkId::new("batch", fixture.name), |b| {
+                b.iter(|| {
+                    let mut output = String::new();
+                    handler
+                        .render_reports(
+                            &mut output,
+                            diagnostics
+                                .iter()
+                                .map(|diagnostic| black_box(as_diagnostic(diagnostic))),
+                        )
+                        .expect("batch render succeeds");
+                    black_box(output);
+                });
+            });
         }
         group.finish();
     }

--- a/src/handlers/graphical/report.rs
+++ b/src/handlers/graphical/report.rs
@@ -12,7 +12,10 @@ use std::fmt::{self, Write};
 
 use owo_colors::OwoColorize;
 
-use super::handler::{GraphicalReportHandler, LinkStyle};
+use super::{
+    handler::{GraphicalReportHandler, LinkStyle},
+    snippet::SpanScannerCache,
+};
 use crate::{Diagnostic, Severity, SourceCode};
 
 impl GraphicalReportHandler {
@@ -29,12 +32,61 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         diagnostic: &dyn Diagnostic,
     ) -> fmt::Result {
+        self.render_report_inner(f, diagnostic, None)
+    }
+
+    /// Render several [`Diagnostic`]s in iterator order while sharing source
+    /// indexing work between reports backed by the same contiguous buffer.
+    ///
+    /// The rendered output is byte-for-byte equivalent to calling
+    /// [`render_report`](Self::render_report) for every diagnostic. Sources
+    /// that do not expose a contiguous buffer continue to use
+    /// [`SourceCode::read_span`](crate::SourceCode::read_span).
+    ///
+    /// Batch rendering retains a temporary line-start index from the beginning
+    /// of each shared source through its furthest queried span. This lets
+    /// diagnostics arrive in any order without repeatedly scanning source
+    /// prefixes; the indexes are dropped when this method returns.
+    ///
+    /// ```
+    /// use miette::{Diagnostic, GraphicalReportHandler, Report};
+    ///
+    /// let reports = [Report::msg("first"), Report::msg("second")];
+    /// let mut output = String::new();
+    /// GraphicalReportHandler::new().render_reports(
+    ///     &mut output,
+    ///     reports.iter().map(|report| report.as_ref() as &dyn Diagnostic),
+    /// )?;
+    /// # Ok::<(), core::fmt::Error>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when writing a rendered report fails.
+    pub fn render_reports<'a>(
+        &self,
+        f: &mut impl fmt::Write,
+        diagnostics: impl IntoIterator<Item = &'a dyn Diagnostic>,
+    ) -> fmt::Result {
+        let mut scanner_cache = SpanScannerCache::new(self.context_lines);
+        for diagnostic in diagnostics {
+            self.render_report_inner(f, diagnostic, Some(&mut scanner_cache))?;
+        }
+        Ok(())
+    }
+
+    fn render_report_inner<'a>(
+        &self,
+        f: &mut impl fmt::Write,
+        diagnostic: &'a dyn Diagnostic,
+        mut scanner_cache: Option<&mut SpanScannerCache<'a>>,
+    ) -> fmt::Result {
         writeln!(f)?;
         self.render_causes(f, diagnostic)?;
         let src = diagnostic.source_code();
-        self.render_snippets(f, diagnostic, src)?;
+        self.render_snippets(f, diagnostic, src, scanner_cache.as_deref_mut())?;
         self.render_footer(f, diagnostic)?;
-        self.render_related(f, diagnostic, src)?;
+        self.render_related(f, diagnostic, src, scanner_cache)?;
         if let Some(footer) = &self.footer {
             writeln!(f)?;
             let width = self.termwidth.saturating_sub(4);
@@ -169,11 +221,12 @@ impl GraphicalReportHandler {
         Ok(())
     }
 
-    fn render_related(
+    fn render_related<'a>(
         &self,
         f: &mut impl fmt::Write,
-        diagnostic: &dyn Diagnostic,
-        parent_src: Option<&dyn SourceCode>,
+        diagnostic: &'a dyn Diagnostic,
+        parent_src: Option<&'a dyn SourceCode>,
+        mut scanner_cache: Option<&mut SpanScannerCache<'a>>,
     ) -> fmt::Result {
         let related = diagnostic.related();
         if !related.is_empty() {
@@ -188,9 +241,9 @@ impl GraphicalReportHandler {
                 inner_renderer.render_header(f, rel)?;
                 inner_renderer.render_causes(f, rel)?;
                 let src = rel.source_code().or(parent_src);
-                inner_renderer.render_snippets(f, rel, src)?;
+                inner_renderer.render_snippets(f, rel, src, scanner_cache.as_deref_mut())?;
                 inner_renderer.render_footer(f, rel)?;
-                inner_renderer.render_related(f, rel, src)?;
+                inner_renderer.render_related(f, rel, src, scanner_cache.as_deref_mut())?;
             }
         }
         Ok(())

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -11,6 +11,7 @@
 use std::{borrow::Cow, cmp::max, fmt};
 
 use owo_colors::OwoColorize;
+use rustc_hash::FxHashMap;
 
 use super::{
     handler::GraphicalReportHandler,
@@ -22,12 +23,42 @@ use crate::{
     source_impls::SpanScanner,
 };
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+struct SourceKey {
+    pointer: *const u8,
+    length: usize,
+}
+
+impl SourceKey {
+    fn new(bytes: &[u8]) -> Self {
+        Self { pointer: bytes.as_ptr(), length: bytes.len() }
+    }
+}
+
+pub(super) struct SpanScannerCache<'a> {
+    context_lines: usize,
+    scanners: FxHashMap<SourceKey, SpanScanner<'a>>,
+}
+
+impl<'a> SpanScannerCache<'a> {
+    pub(super) fn new(context_lines: usize) -> Self {
+        Self { context_lines, scanners: FxHashMap::default() }
+    }
+
+    fn scanner(&mut self, bytes: &'a [u8]) -> &mut SpanScanner<'a> {
+        self.scanners.entry(SourceKey::new(bytes)).or_insert_with(|| {
+            SpanScanner::new_batch(bytes, self.context_lines, self.context_lines)
+        })
+    }
+}
+
 impl GraphicalReportHandler {
-    pub(super) fn render_snippets(
+    pub(super) fn render_snippets<'a>(
         &self,
         f: &mut impl fmt::Write,
-        diagnostic: &dyn Diagnostic,
-        opt_source: Option<&dyn SourceCode>,
+        diagnostic: &'a dyn Diagnostic,
+        opt_source: Option<&'a dyn SourceCode>,
+        scanner_cache: Option<&mut SpanScannerCache<'a>>,
     ) -> fmt::Result {
         let Some(source) = opt_source else { return Ok(()) };
         let mut labels = diagnostic.labels();
@@ -36,37 +67,62 @@ impl GraphicalReportHandler {
         }
         labels.sort_unstable_by_key(|l| l.inner().offset());
 
-        // When the source exposes its backing buffer, share one forward scan
-        // across every span lookup below (one per label plus one per merge
-        // attempt); each `read_span` otherwise scans the source from byte 0
-        // again. The scanner bypasses the source's own `read_span`, so
-        // re-attach the source's name the way `NamedSource` would.
-        let mut scanner = source
-            .contiguous_bytes()
-            .map(|bytes| SpanScanner::new(bytes, self.context_lines, self.context_lines));
         let source_name = source.name();
-        let mut read = |span: &SourceSpan| match scanner.as_mut() {
-            Some(scanner) => scanner.read_span(*span).map(|contents| match source_name {
-                Some(name) => MietteSpanContents::new_named(
-                    Cow::Borrowed(name),
-                    contents.data(),
-                    *contents.span(),
-                    contents.line(),
-                    contents.column(),
-                    contents.line_count(),
-                ),
-                None => contents,
-            }),
-            None => source.read_span(span, self.context_lines, self.context_lines),
-        };
+        if let Some(bytes) = source.contiguous_bytes() {
+            if let Some(scanner_cache) = scanner_cache {
+                let scanner = scanner_cache.scanner(bytes);
+                return self.render_snippets_with(f, &labels, |span| {
+                    scanner
+                        .read_span(*span)
+                        .map(|contents| Self::attach_source_name(contents, source_name))
+                });
+            }
 
-        if let [label] = labels.as_slice() {
+            // A single report still shares one forward scan across all of its
+            // labels and merge attempts, without retaining a batch cache.
+            let mut scanner = SpanScanner::new(bytes, self.context_lines, self.context_lines);
+            return self.render_snippets_with(f, &labels, |span| {
+                scanner
+                    .read_span(*span)
+                    .map(|contents| Self::attach_source_name(contents, source_name))
+            });
+        }
+
+        self.render_snippets_with(f, &labels, |span| {
+            source.read_span(span, self.context_lines, self.context_lines)
+        })
+    }
+
+    fn attach_source_name<'a>(
+        contents: MietteSpanContents<'a>,
+        source_name: Option<&'a str>,
+    ) -> MietteSpanContents<'a> {
+        match source_name {
+            Some(name) => MietteSpanContents::new_named(
+                Cow::Borrowed(name),
+                contents.data(),
+                *contents.span(),
+                contents.line(),
+                contents.column(),
+                contents.line_count(),
+            ),
+            None => contents,
+        }
+    }
+
+    fn render_snippets_with<'a>(
+        &self,
+        f: &mut impl fmt::Write,
+        labels: &[LabeledSpan],
+        mut read: impl FnMut(&SourceSpan) -> Result<MietteSpanContents<'a>, crate::MietteError>,
+    ) -> fmt::Result {
+        if let [label] = labels {
             let contents = read(label.inner()).map_err(|_| fmt::Error)?;
-            return self.render_context(f, label, &contents, &labels);
+            return self.render_context(f, label, &contents, labels);
         }
 
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
-        for right in &labels {
+        for right in labels {
             let right_conts = read(right.inner()).map_err(|_| fmt::Error)?;
 
             if contexts.is_empty() {
@@ -97,7 +153,7 @@ impl GraphicalReportHandler {
             contexts.push((Cow::Borrowed(right), right_conts));
         }
         for (ctx, conts) in contexts {
-            self.render_context(f, &ctx, &conts, &labels[..])?;
+            self.render_context(f, &ctx, &conts, labels)?;
         }
 
         Ok(())

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -479,6 +479,26 @@ impl<'a> LineIndex<'a> {
         self.frontier = cut;
     }
 
+    /// First batch query: retain every line start from the beginning of the
+    /// source so later queries can move backwards without rescanning.
+    fn init_from_start(&mut self, cut: usize) {
+        let prefix = &self.input[..cut];
+        if memchr::memchr(b'\r', prefix).is_none() {
+            // Reserve exactly once before retaining LF-only line starts. The
+            // extra SIMD counting pass is cheaper than repeatedly growing and
+            // copying the index for large source files.
+            let line_count = bytecount::count(prefix, b'\n');
+            self.line_starts.reserve(line_count + 1);
+            self.line_starts.push(0);
+            self.line_starts.extend(memchr::memchr_iter(b'\n', prefix).map(|pos| pos + 1));
+            self.frontier = cut;
+            return;
+        }
+
+        self.line_starts.push(0);
+        self.cover(cut);
+    }
+
     /// Extend the index so every break in `[0, target)` is recorded, with one
     /// bulk `memchr` pass. (A `read_span`-shaped `target` never splits a
     /// `\r\n` pair, but hold the pair back a byte if one would be.)
@@ -692,6 +712,7 @@ impl<'index, 'source> IndexedReader<'index, 'source> {
 pub(crate) struct SpanScanner<'a> {
     context: ContextLines,
     index: LineIndex<'a>,
+    retain_prefix: bool,
 }
 
 #[cfg(feature = "fancy-base")]
@@ -704,6 +725,22 @@ impl<'a> SpanScanner<'a> {
         Self {
             context: ContextLines::new(context_lines_before, context_lines_after),
             index: LineIndex::new(input),
+            retain_prefix: false,
+        }
+    }
+
+    /// Create a scanner for rendering a batch of reports. Unlike [`Self::new`],
+    /// this retains the full scanned prefix so queries may arrive in any order
+    /// without rescanning source bytes.
+    pub(crate) fn new_batch(
+        input: &'a [u8],
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Self {
+        Self {
+            context: ContextLines::new(context_lines_before, context_lines_after),
+            index: LineIndex::new(input),
+            retain_prefix: true,
         }
     }
 
@@ -715,7 +752,11 @@ impl<'a> SpanScanner<'a> {
         let request = SpanRequest::new(span);
         let cut = request.prefix_end(self.index.input);
         if self.index.is_empty() {
-            self.index.init(cut, self.context.before);
+            if self.retain_prefix {
+                self.index.init_from_start(cut);
+            } else {
+                self.index.init(cut, self.context.before);
+            }
         } else {
             if cut < self.index.origin().expect("a non-empty index has an origin") {
                 return self.read_unindexed(request);
@@ -1163,8 +1204,9 @@ mod scanner_tests {
     /// queries, so single-shot checks would miss its interesting bugs. Covers
     /// LF / CRLF / lone-CR and multibyte sources; spans of any alignment
     /// (byte offsets, not char boundaries — neither function cares) including
-    /// past-EOF ones; queries in random order (which exercises the
-    /// out-of-index fallbacks) and in the renderer's sorted-then-merge order.
+    /// past-EOF ones; queries in random order through both the context-window
+    /// and full-prefix batch indexes, and in the renderer's sorted-then-merge
+    /// order.
     #[test]
     #[cfg_attr(
         miri,
@@ -1200,6 +1242,15 @@ mod scanner_tests {
                     // Random order: queries may jump backwards past the
                     // index origin.
                     let mut scanner = SpanScanner::new(input, before, after);
+                    for i in 0..spans.len() {
+                        check(&mut scanner, input, spans[i], before, after, &spans[..i]);
+                        checked += 1;
+                    }
+
+                    // The batch renderer preserves input order. Its scanner
+                    // retains the complete prefix so the same random jumps do
+                    // not need the unindexed fallback.
+                    let mut scanner = SpanScanner::new_batch(input, before, after);
                     for i in 0..spans.len() {
                         check(&mut scanner, input, spans[i], before, after, &spans[..i]);
                         checked += 1;

--- a/tests/batch_render.rs
+++ b/tests/batch_render.rs
@@ -1,0 +1,169 @@
+#![cfg(feature = "fancy-no-backtrace")]
+
+use std::{fmt, fmt::Write as _, sync::Arc};
+
+use miette::{
+    Diagnostic, Error as Report, GraphicalReportHandler, GraphicalTheme, LabeledSpan,
+    MietteDiagnostic, NamedSource, SourceSpan,
+};
+use thiserror::Error;
+
+fn handler() -> GraphicalReportHandler {
+    GraphicalReportHandler::new_themed(GraphicalTheme::none()).with_width(80)
+}
+
+fn source_lines(prefix: &str, count: usize) -> String {
+    let mut source = String::new();
+    for line in 0..count {
+        writeln!(source, "{prefix} {line:02}").unwrap();
+    }
+    source
+}
+
+fn line_offset(prefix: &str, line: usize) -> u32 {
+    u32::try_from(line * (prefix.len() + 4)).unwrap()
+}
+
+fn diagnostic(
+    source: &Arc<NamedSource<String>>,
+    message: impl Into<String>,
+    span: SourceSpan,
+) -> Report {
+    let diagnostic =
+        MietteDiagnostic::new(message.into()).with_label(LabeledSpan::new_with_span(None, span));
+    Report::new(diagnostic).with_source_code(Arc::clone(source))
+}
+
+fn as_diagnostic(report: &Report) -> &dyn Diagnostic {
+    report.as_ref()
+}
+
+fn render_individually(reports: &[Report]) -> (fmt::Result, String) {
+    let mut output = String::new();
+    let handler = handler();
+    let result = reports
+        .iter()
+        .try_for_each(|report| handler.render_report(&mut output, as_diagnostic(report)));
+    (result, output)
+}
+
+fn render_batch(reports: &[Report]) -> (fmt::Result, String) {
+    let mut output = String::new();
+    let result = handler().render_reports(&mut output, reports.iter().map(as_diagnostic));
+    (result, output)
+}
+
+#[test]
+fn preserves_input_order_for_shared_sources() {
+    let source_text = source_lines("line", 40);
+    let source = Arc::new(NamedSource::new("shared.rs", source_text));
+    let reports = [
+        diagnostic(&source, "last", (line_offset("line", 35), 7).into()),
+        diagnostic(&source, "first", (line_offset("line", 2), 7).into()),
+        diagnostic(&source, "middle", (line_offset("line", 20), 7).into()),
+    ];
+
+    let individual = render_individually(&reports);
+    let batch = render_batch(&reports);
+    assert_eq!(individual.0, batch.0);
+    assert_eq!(individual.1, batch.1);
+    assert!(batch.1.find("last").unwrap() < batch.1.find("first").unwrap());
+    assert!(batch.1.find("first").unwrap() < batch.1.find("middle").unwrap());
+}
+
+#[test]
+fn reuses_interleaved_sources_without_reordering() {
+    let first = Arc::new(NamedSource::new("first.rs", source_lines("first", 30)));
+    let second = Arc::new(NamedSource::new("second.rs", source_lines("second", 30)));
+    let reports = [
+        diagnostic(&first, "first-late", (line_offset("first", 25), 8).into()),
+        diagnostic(&second, "second-late", (line_offset("second", 20), 9).into()),
+        diagnostic(&first, "first-early", (line_offset("first", 3), 8).into()),
+        diagnostic(&second, "second-early", (line_offset("second", 1), 9).into()),
+    ];
+
+    let individual = render_individually(&reports);
+    let batch = render_batch(&reports);
+    assert_eq!(individual.0, batch.0);
+    assert_eq!(individual.1, batch.1);
+}
+
+#[test]
+fn keeps_names_separate_when_sources_share_bytes() {
+    static SOURCE: &str = "shared bytes\nsecond line\n";
+    let first = Arc::new(NamedSource::new("first-name.rs", SOURCE));
+    let second = Arc::new(NamedSource::new("second-name.rs", SOURCE));
+    let reports = [
+        Report::new(
+            MietteDiagnostic::new("first name")
+                .with_label(LabeledSpan::new_with_span(None, SourceSpan::from((13, 6)))),
+        )
+        .with_source_code(first),
+        Report::new(
+            MietteDiagnostic::new("second name")
+                .with_label(LabeledSpan::new_with_span(None, SourceSpan::from((0, 6)))),
+        )
+        .with_source_code(second),
+    ];
+
+    let individual = render_individually(&reports);
+    let batch = render_batch(&reports);
+    assert_eq!(individual.0, batch.0);
+    assert_eq!(individual.1, batch.1);
+    assert!(batch.1.contains("first-name.rs"));
+    assert!(batch.1.contains("second-name.rs"));
+}
+
+#[test]
+fn preserves_related_diagnostics_and_inherited_sources() {
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("child")]
+    struct Child {
+        #[label]
+        span: SourceSpan,
+    }
+
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("parent")]
+    struct Parent {
+        #[source_code]
+        src: Arc<NamedSource<String>>,
+        #[label]
+        span: SourceSpan,
+        #[related]
+        children: Vec<Child>,
+    }
+
+    let source = Arc::new(NamedSource::new("related.rs", source_lines("line", 30)));
+    let reports = [Report::new(Parent {
+        src: source,
+        span: (line_offset("line", 20), 7).into(),
+        children: vec![Child { span: (line_offset("line", 2), 7).into() }],
+    })];
+
+    let individual = render_individually(&reports);
+    let batch = render_batch(&reports);
+    assert_eq!(individual.0, batch.0);
+    assert_eq!(individual.1, batch.1);
+}
+
+#[test]
+fn preserves_partial_output_on_invalid_span() {
+    let source = Arc::new(NamedSource::new("invalid.rs", "valid source\n".to_string()));
+    let reports = [
+        diagnostic(&source, "valid", (0, 5).into()),
+        diagnostic(&source, "invalid", (100, 4).into()),
+    ];
+
+    let individual = render_individually(&reports);
+    let batch = render_batch(&reports);
+    assert!(individual.0.is_err());
+    assert!(batch.0.is_err());
+    assert_eq!(individual.1, batch.1);
+}
+
+#[test]
+fn empty_batch_writes_nothing() {
+    let reports: [Report; 0] = [];
+    assert_eq!(render_batch(&reports), (Ok(()), String::new()));
+}


### PR DESCRIPTION
Adds an order-preserving batch API for `GraphicalReportHandler` and reuses source indexes across reports. Large-fixture benchmarks improve rendering time by 21–27% while preserving byte-identical output.

Validated with the full feature test suite, clippy, doctests, and comparative benchmarks.