### PR TITLE
refactor: narrow diagnostic protocol

### DIFF
--- a/benches/render.rs
+++ b/benches/render.rs
@@ -25,7 +25,7 @@ use criterion::{
     BatchSize, BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main,
 };
 use miette::{
-    Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, NamedSource, Severity,
+    Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, NamedSource, Severity,
     SourceCode, SourceSpan,
 };
 
@@ -65,7 +65,7 @@ struct DiagnosticCase {
 struct LintDiagnostic {
     message: &'static str,
     help: &'static str,
-    labels: Labels,
+    labels: Vec<LabeledSpan>,
     source: Arc<NamedSource<String>>,
 }
 
@@ -96,8 +96,8 @@ impl Diagnostic for LintDiagnostic {
         ))
     }
 
-    fn labels(&self) -> Labels {
-        self.labels.clone()
+    fn labels(&self) -> &[LabeledSpan] {
+        &self.labels
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
@@ -196,7 +196,7 @@ fn declared_diagnostic(fixture: &Fixture) -> Error {
 /// The one-label warning against a freshly created source, whose embedded
 /// scan cache is necessarily empty.
 fn cold_declared_diagnostic(fixture: &Fixture) -> Error {
-    let source = Arc::new(NamedSource::new(fixture.name, fixture.source.inner().clone()));
+    let source = Arc::new(fixture.source.as_ref().clone());
     declared_diagnostic_with_source(fixture, source)
 }
 
@@ -204,11 +204,10 @@ fn declared_diagnostic_with_source(fixture: &Fixture, source: Arc<NamedSource<St
     Box::new(LintDiagnostic {
         message: "Variable 'resolve' is declared but never used.",
         help: "Consider removing this declaration.",
-        labels: LabeledSpan::new_with_span(
+        labels: vec![LabeledSpan::new_with_span(
             Some("'resolve' is declared here".to_string()),
             fixture.declaration_span,
-        )
-        .into(),
+        )],
         source,
     })
 }
@@ -218,7 +217,7 @@ fn assigned_diagnostic(fixture: &Fixture) -> Error {
     Box::new(LintDiagnostic {
         message: "Variable 'resolve' is assigned a value but never used.",
         help: "Did you mean to use this variable?",
-        labels: [
+        labels: vec![
             LabeledSpan::new_with_span(
                 Some("'resolve' is declared here".to_string()),
                 fixture.declaration_span,
@@ -227,8 +226,7 @@ fn assigned_diagnostic(fixture: &Fixture) -> Error {
                 Some("it was last assigned here".to_string()),
                 fixture.assignment_span,
             ),
-        ]
-        .into(),
+        ],
         source: Arc::clone(&fixture.source),
     })
 }
@@ -246,7 +244,6 @@ fn bench(c: &mut Criterion) {
             b.iter(|| {
                 let contents = fixture
                     .source
-                    .inner()
                     .read_span(black_box(&fixture.declaration_span), 1, 1)
                     .expect("span within source");
                 black_box(contents);

--- a/src/handlers/graphical/snippet.rs
+++ b/src/handlers/graphical/snippet.rs
@@ -29,41 +29,39 @@ impl GraphicalReportHandler {
         opt_source: Option<&dyn SourceCode>,
     ) -> fmt::Result {
         let Some(source) = opt_source else { return Ok(()) };
-        let mut labels = diagnostic.labels();
+        let labels = diagnostic.labels();
         if labels.is_empty() {
             return Ok(());
         }
-        labels.sort_unstable_by_key(|l| l.inner().offset());
 
         // When the source exposes its backing buffer, share one forward scan
         // across every span lookup below (one per label plus one per merge
         // attempt); each `read_span` otherwise scans the source from byte 0
-        // again. The scanner bypasses the source's own `read_span`, so
-        // re-attach the source's name the way `NamedSource` would.
+        // again.
         let mut scanner = source.contiguous_bytes().map(|bytes| SpanScanner::new(bytes, 1, 1));
         let source_name = source.name();
         let mut read = |span: &SourceSpan| match scanner.as_mut() {
-            Some(scanner) => scanner.read_span(*span).map(|contents| match source_name {
-                Some(name) => SpanContents::new_named(
-                    Cow::Borrowed(name),
-                    contents.data(),
-                    *contents.span(),
-                    contents.line(),
-                    contents.column(),
-                    contents.line_count(),
-                ),
-                None => contents,
-            }),
+            Some(scanner) => scanner.read_span(*span),
             None => source.read_span(span, 1, 1),
         };
 
-        if let [label] = labels.as_slice() {
+        if let [label] = labels {
             let contents = read(label.inner()).ok_or(fmt::Error)?;
-            return self.render_context(f, label, &contents, &labels);
+            return self.render_context(f, label, &contents, &[label], source_name);
         }
 
+        let mut inline_labels = [&labels[0], &labels[1]];
+        let mut heap_labels = Vec::new();
+        let labels = if labels.len() == 2 {
+            inline_labels.sort_unstable_by_key(|label| label.offset());
+            inline_labels.as_slice()
+        } else {
+            heap_labels.extend(labels);
+            heap_labels.sort_unstable_by_key(|label| label.offset());
+            heap_labels.as_slice()
+        };
         let mut contexts: Vec<(Cow<'_, LabeledSpan>, _)> = Vec::with_capacity(labels.len());
-        for right in &labels {
+        for &right in labels {
             let right_conts = read(right.inner()).ok_or(fmt::Error)?;
 
             if contexts.is_empty() {
@@ -94,7 +92,7 @@ impl GraphicalReportHandler {
             contexts.push((Cow::Borrowed(right), right_conts));
         }
         for (ctx, conts) in contexts {
-            self.render_context(f, &ctx, &conts, &labels[..])?;
+            self.render_context(f, &ctx, &conts, labels, source_name)?;
         }
 
         Ok(())
@@ -105,7 +103,8 @@ impl GraphicalReportHandler {
         f: &mut impl fmt::Write,
         context: &LabeledSpan,
         contents: &SpanContents<'_>,
-        labels: &[LabeledSpan],
+        labels: &[&LabeledSpan],
+        source_name: Option<&str>,
     ) -> fmt::Result {
         let lines = self.get_lines(contents);
 
@@ -121,6 +120,7 @@ impl GraphicalReportHandler {
         // sorting is your friend
         let labels = labels
             .iter()
+            .copied()
             .zip(self.theme.styles.highlights.iter().copied().cycle())
             .map(|(label, st)| FancySpan::new(label.label(), *label.inner(), st))
             .collect::<Vec<_>>();
@@ -163,7 +163,7 @@ impl GraphicalReportHandler {
             None => (contents.line(), contents.column()),
         };
 
-        match contents.name() {
+        match source_name {
             Some(source_name) => {
                 let source_name = source_name.style(self.theme.styles.link);
                 writeln!(f, "[{}:{}:{}]", source_name, primary_line + 1, primary_column + 1)?;

--- a/src/handlers/json.rs
+++ b/src/handlers/json.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Write};
 
-use crate::{Severity, SourceCode, protocol::Diagnostic};
+use crate::{Severity, protocol::Diagnostic};
 
 /**
 Renders diagnostics as machine-readable JSON.
@@ -58,6 +58,7 @@ impl JSONReportHandler {
     /// # Errors
     ///
     /// Returns an error when writing the rendered report fails.
+    #[expect(clippy::unused_self, reason = "keeps a consistent renderer API")]
     pub fn render_report(
         &self,
         f: &mut impl fmt::Write,
@@ -83,13 +84,13 @@ impl JSONReportHandler {
         if let Some(note) = diagnostic.note() {
             write!(f, r#""note": "{}","#, escape(&note))?;
         }
-        if let Some(src) = diagnostic.source_code() {
-            self.render_snippets(f, diagnostic, src)?;
+        if let Some(source) = diagnostic.source_code() {
+            write!(f, r#""filename": "{}","#, escape(source.name().unwrap_or_default()))?;
         }
         {
             write!(f, r#""labels": ["#)?;
             let mut add_comma = false;
-            for label in &diagnostic.labels() {
+            for label in diagnostic.labels() {
                 if add_comma {
                     write!(f, ",")?;
                 } else {
@@ -119,22 +120,6 @@ impl JSONReportHandler {
         }
         write!(f, r#""related": []"#)?;
         write!(f, "}}")
-    }
-
-    #[expect(clippy::unused_self, reason = "kept as a renderer method for call-site consistency")]
-    fn render_snippets(
-        &self,
-        f: &mut impl fmt::Write,
-        diagnostic: &dyn Diagnostic,
-        source: &dyn SourceCode,
-    ) -> fmt::Result {
-        if let Some(label) = diagnostic.labels().first() {
-            if let Some(span_content) = source.read_span(label.inner(), 0, 0) {
-                let filename = span_content.name().unwrap_or_default();
-                return write!(f, r#""filename": "{}","#, escape(filename));
-            }
-        }
-        write!(f, r#""filename": "","#)
     }
 }
 

--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt};
+use std::fmt;
 
 use crate::{SourceCode, SpanContents};
 
@@ -28,13 +28,6 @@ impl<S: SourceCode + 'static> NamedSource<S> {
     {
         Self { source, name: name.as_ref().to_string() }
     }
-
-    /// Returns a reference the inner [`SourceCode`] type for this
-    /// `NamedSource`.
-    #[must_use]
-    pub fn inner(&self) -> &S {
-        &self.source
-    }
 }
 
 impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
@@ -44,17 +37,7 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
         context_lines_before: usize,
         context_lines_after: usize,
     ) -> Option<SpanContents<'a>> {
-        let inner_contents =
-            self.inner().read_span(span, context_lines_before, context_lines_after)?;
-        let contents = SpanContents::new_named(
-            Cow::Borrowed(self.name.as_str()),
-            inner_contents.data(),
-            *inner_contents.span(),
-            inner_contents.line(),
-            inner_contents.column(),
-            inner_contents.line_count(),
-        );
-        Some(contents)
+        self.source.read_span(span, context_lines_before, context_lines_after)
     }
 
     fn name(&self) -> Option<&str> {
@@ -62,6 +45,6 @@ impl<S: SourceCode + 'static> SourceCode for NamedSource<S> {
     }
 
     fn contiguous_bytes(&self) -> Option<&[u8]> {
-        self.inner().contiguous_bytes()
+        self.source.contiguous_bytes()
     }
 }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,13 +3,7 @@ This module defines the core of the miette protocol: a series of types and
 traits that you can implement to get access to miette's (and related library's)
 full reporting and such features.
 */
-use std::{
-    borrow::Cow,
-    error::Error,
-    mem,
-    ops::{Deref, DerefMut, Range},
-    slice::{Iter, IterMut},
-};
+use std::{borrow::Cow, error::Error, ops::Range};
 
 /// Adds rich metadata to your Error that can be used by
 /// Rich metadata that renderers use to produce human-friendly error messages.
@@ -57,177 +51,10 @@ pub trait Diagnostic: Error {
 
     /// Labels to apply to this `Diagnostic`'s [`Diagnostic::source_code`]
     ///
-    /// Returns the owned [`Labels`] container. For the common one/two-label
-    /// case this is allocation-free (the labels are stored inline), and it
-    /// avoids the boxed-iterator allocation the previous signature required.
-    fn labels(&self) -> crate::Labels {
-        crate::Labels::None
-    }
-}
-
-impl Error for Box<dyn Diagnostic + Send + Sync> {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        (**self).source()
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
-        self.source()
-    }
-}
-
-impl<T: Diagnostic + Send + Sync + 'static> From<T>
-    for Box<dyn Diagnostic + Send + Sync + 'static>
-{
-    fn from(diagnostic: T) -> Self {
-        Box::new(diagnostic)
-    }
-}
-
-/// Owned labels attached to a [`Diagnostic`].
-///
-/// The common one- and two-label cases are stored inline.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum Labels {
-    /// No labels.
-    #[default]
-    None,
-    /// A single label.
-    One([LabeledSpan; 1]),
-    /// Two labels.
-    Two([LabeledSpan; 2]),
-    /// Three or more labels.
-    Many(Vec<LabeledSpan>),
-}
-
-impl Labels {
-    /// Returns the labels as a slice.
-    pub fn as_slice(&self) -> &[LabeledSpan] {
-        match self {
-            Self::None => &[],
-            Self::One(labels) => labels,
-            Self::Two(labels) => labels,
-            Self::Many(labels) => labels,
-        }
-    }
-
-    /// Returns the labels as a mutable slice.
-    pub fn as_mut_slice(&mut self) -> &mut [LabeledSpan] {
-        match self {
-            Self::None => &mut [],
-            Self::One(labels) => labels,
-            Self::Two(labels) => labels,
-            Self::Many(labels) => labels,
-        }
-    }
-
-    /// Returns whether there are no labels.
-    pub fn is_empty(&self) -> bool {
-        matches!(self, Self::None)
-    }
-
-    /// Returns the number of labels.
-    pub fn len(&self) -> usize {
-        self.as_slice().len()
-    }
-
-    /// Appends a label.
-    pub fn push(&mut self, label: LabeledSpan) {
-        if let Self::Many(labels) = self {
-            labels.push(label);
-            return;
-        }
-        *self = match mem::take(self) {
-            Self::None => Self::One([label]),
-            Self::One([a]) => Self::Two([a, label]),
-            Self::Two([a, b]) => Self::Many(vec![a, b, label]),
-            Self::Many(_) => unreachable!("handled above"),
-        };
-    }
-}
-
-impl Deref for Labels {
-    type Target = [LabeledSpan];
-
-    fn deref(&self) -> &Self::Target {
-        self.as_slice()
-    }
-}
-
-impl DerefMut for Labels {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.as_mut_slice()
-    }
-}
-
-impl<'a> IntoIterator for &'a Labels {
-    type Item = &'a LabeledSpan;
-    type IntoIter = Iter<'a, LabeledSpan>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_slice().iter()
-    }
-}
-
-impl<'a> IntoIterator for &'a mut Labels {
-    type Item = &'a mut LabeledSpan;
-    type IntoIter = IterMut<'a, LabeledSpan>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_mut_slice().iter_mut()
-    }
-}
-
-impl Extend<LabeledSpan> for Labels {
-    fn extend<I: IntoIterator<Item = LabeledSpan>>(&mut self, iter: I) {
-        let mut iter = iter.into_iter();
-        while !matches!(self, Self::Many(_)) {
-            let Some(label) = iter.next() else { return };
-            self.push(label);
-        }
-        if let Self::Many(labels) = self {
-            labels.reserve(iter.size_hint().0);
-            labels.extend(iter);
-        }
-    }
-}
-
-impl FromIterator<LabeledSpan> for Labels {
-    fn from_iter<I: IntoIterator<Item = LabeledSpan>>(iter: I) -> Self {
-        let mut iter = iter.into_iter();
-        if iter.size_hint().0 > 2 {
-            return Self::Many(iter.collect());
-        }
-        let Some(a) = iter.next() else { return Self::None };
-        let Some(b) = iter.next() else { return Self::One([a]) };
-        let Some(c) = iter.next() else { return Self::Two([a, b]) };
-        let mut labels = Vec::with_capacity(3 + iter.size_hint().0);
-        labels.extend([a, b, c]);
-        labels.extend(iter);
-        Self::Many(labels)
-    }
-}
-
-impl From<Vec<LabeledSpan>> for Labels {
-    fn from(labels: Vec<LabeledSpan>) -> Self {
-        if labels.len() <= 2 { labels.into_iter().collect() } else { Self::Many(labels) }
-    }
-}
-
-impl From<LabeledSpan> for Labels {
-    fn from(label: LabeledSpan) -> Self {
-        Self::One([label])
-    }
-}
-
-impl From<[LabeledSpan; 1]> for Labels {
-    fn from(labels: [LabeledSpan; 1]) -> Self {
-        Self::One(labels)
-    }
-}
-
-impl From<[LabeledSpan; 2]> for Labels {
-    fn from(labels: [LabeledSpan; 2]) -> Self {
-        Self::Two(labels)
+    /// The diagnostic retains ownership of the labels; renderers only borrow
+    /// them for the duration of a report.
+    fn labels(&self) -> &[LabeledSpan] {
+        &[]
     }
 }
 
@@ -311,8 +138,8 @@ pub struct LabeledSpan {
 impl LabeledSpan {
     /// Makes a new labeled span.
     #[must_use]
-    pub const fn new(label: Option<String>, offset: ByteOffset, len: u32) -> Self {
-        Self { label, span: SourceSpan::new(SourceOffset(offset), len), primary: false }
+    pub const fn new(label: Option<String>, offset: u32, len: u32) -> Self {
+        Self { label, span: SourceSpan { offset, length: len }, primary: false }
     }
 
     /// Makes a new labeled span using an existing span.
@@ -328,8 +155,8 @@ impl LabeledSpan {
     }
 
     /// Change the offset of the span.
-    pub fn set_span_offset(&mut self, offset: ByteOffset) {
-        self.span.offset = SourceOffset(offset);
+    pub fn set_span_offset(&mut self, offset: u32) {
+        self.span.offset = offset;
     }
 
     /// Makes a new label at specified span
@@ -379,7 +206,7 @@ impl LabeledSpan {
 
     /// Returns the 0-based starting byte offset.
     #[must_use]
-    pub const fn offset(&self) -> ByteOffset {
+    pub const fn offset(&self) -> u32 {
         self.span.offset()
     }
 
@@ -417,8 +244,6 @@ pub struct SpanContents<'a> {
     column: usize,
     // Number of line in this snippet.
     line_count: usize,
-    // Optional filename
-    name: Option<Cow<'a, str>>,
 }
 
 impl<'a> SpanContents<'a> {
@@ -431,20 +256,7 @@ impl<'a> SpanContents<'a> {
         column: usize,
         line_count: usize,
     ) -> Self {
-        Self { data, span, line, column, line_count, name: None }
-    }
-
-    /// Make a new [`SpanContents`] object, with a name for its file.
-    #[must_use]
-    pub const fn new_named(
-        name: Cow<'a, str>,
-        data: &'a [u8],
-        span: SourceSpan,
-        line: usize,
-        column: usize,
-        line_count: usize,
-    ) -> Self {
-        Self { data, span, line, column, line_count, name: Some(name) }
+        Self { data, span, line, column, line_count }
     }
 
     /// Reference to the covered source data, in bytes.
@@ -471,34 +283,23 @@ impl<'a> SpanContents<'a> {
     pub const fn line_count(&self) -> usize {
         self.line_count
     }
-
-    /// The source name, if one is available.
-    pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
-    }
 }
 
 /// Span within a [`SourceCode`]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct SourceSpan {
     /// The start of the span.
-    offset: SourceOffset,
+    offset: u32,
     /// The total length of the span, in bytes.
     length: u32,
 }
 
 impl SourceSpan {
-    /// Create a new [`SourceSpan`].
-    #[must_use]
-    pub const fn new(start: SourceOffset, length: u32) -> Self {
-        Self { offset: start, length }
-    }
-
     /// The absolute offset, in bytes, from the beginning of a [`SourceCode`].
     #[must_use]
     #[expect(clippy::trivially_copy_pass_by_ref, reason = "retained for public API compatibility")]
-    pub const fn offset(&self) -> ByteOffset {
-        self.offset.offset()
+    pub const fn offset(&self) -> u32 {
+        self.offset
     }
 
     /// Total length of the [`SourceSpan`], in bytes.
@@ -517,61 +318,17 @@ impl SourceSpan {
     }
 }
 
-impl From<(ByteOffset, u32)> for SourceSpan {
-    fn from((start, len): (ByteOffset, u32)) -> Self {
-        Self { offset: start.into(), length: len }
+impl From<(u32, u32)> for SourceSpan {
+    fn from((start, len): (u32, u32)) -> Self {
+        Self { offset: start, length: len }
     }
 }
 
-impl From<(SourceOffset, u32)> for SourceSpan {
-    fn from((start, len): (SourceOffset, u32)) -> Self {
-        Self::new(start, len)
-    }
-}
-
-impl From<Range<ByteOffset>> for SourceSpan {
-    fn from(range: Range<ByteOffset>) -> Self {
+impl From<Range<u32>> for SourceSpan {
+    fn from(range: Range<u32>) -> Self {
         // `Range::len` returns `0` for empty/reversed ranges, matching the
         // previous behavior and avoiding underflow.
         let length = u32::try_from(range.len()).unwrap_or(u32::MAX);
-        Self { offset: range.start.into(), length }
-    }
-}
-
-impl From<SourceOffset> for SourceSpan {
-    fn from(offset: SourceOffset) -> Self {
-        Self { offset, length: 0 }
-    }
-}
-
-impl From<ByteOffset> for SourceSpan {
-    fn from(offset: ByteOffset) -> Self {
-        Self { offset: offset.into(), length: 0 }
-    }
-}
-
-/**
-"Raw" type for the byte offset from the beginning of a [`SourceCode`].
-*/
-pub type ByteOffset = u32;
-
-/**
-Newtype that represents the [`ByteOffset`] from the beginning of a [`SourceCode`]
-*/
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct SourceOffset(ByteOffset);
-
-impl SourceOffset {
-    /// Actual byte offset.
-    #[must_use]
-    #[expect(clippy::trivially_copy_pass_by_ref, reason = "retained for public API compatibility")]
-    pub const fn offset(&self) -> ByteOffset {
-        self.0
-    }
-}
-
-impl From<ByteOffset> for SourceOffset {
-    fn from(bytes: ByteOffset) -> Self {
-        SourceOffset(bytes)
+        Self { offset: range.start, length }
     }
 }

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use miette::{Diagnostic, LabeledSpan, Labels, SourceSpan};
+use miette::{Diagnostic, SourceSpan};
 
 #[derive(Debug)]
 struct TestDiagnostic;
@@ -15,17 +15,6 @@ impl std::error::Error for TestDiagnostic {}
 impl Diagnostic for TestDiagnostic {}
 
 #[test]
-fn labels_store_small_collections_inline() {
-    let mut labels = Labels::default();
-    labels.push(LabeledSpan::at(1..2, "first"));
-    assert!(matches!(labels, Labels::One(_)));
-    labels.push(LabeledSpan::at(3..4, "second"));
-    assert!(matches!(labels, Labels::Two(_)));
-    labels.push(LabeledSpan::at(5..6, "third"));
-    assert!(matches!(labels, Labels::Many(_)));
-}
-
-#[test]
 fn spans_convert_from_offsets_and_ranges() {
     assert_eq!(SourceSpan::from((3, 4)).offset(), 3);
     assert_eq!(SourceSpan::from((3, 4)).len(), 4);
@@ -34,6 +23,6 @@ fn spans_convert_from_offsets_and_ranges() {
 
 #[test]
 fn diagnostics_can_be_owned_as_trait_objects() {
-    let diagnostic: Box<dyn Diagnostic + Send + Sync> = TestDiagnostic.into();
+    let diagnostic: Box<dyn Diagnostic + Send + Sync> = Box::new(TestDiagnostic);
     assert_eq!(diagnostic.to_string(), "broken");
 }

--- a/tests/renderers.rs
+++ b/tests/renderers.rs
@@ -1,13 +1,14 @@
 use std::{borrow::Cow, fmt};
 
 use miette::{
-    Diagnostic, GraphicalReportHandler, GraphicalTheme, JSONReportHandler, LabeledSpan, Labels,
+    Diagnostic, GraphicalReportHandler, GraphicalTheme, JSONReportHandler, LabeledSpan,
     NamedSource, Severity, SourceCode,
 };
 
 #[derive(Debug)]
 struct TestDiagnostic {
     source: NamedSource<String>,
+    labels: [LabeledSpan; 1],
 }
 
 impl fmt::Display for TestDiagnostic {
@@ -31,8 +32,8 @@ impl Diagnostic for TestDiagnostic {
         Some(Cow::Borrowed("remove it"))
     }
 
-    fn labels(&self) -> Labels {
-        Labels::One([LabeledSpan::at(4..5, "here")])
+    fn labels(&self) -> &[LabeledSpan] {
+        &self.labels
     }
 
     fn source_code(&self) -> Option<&dyn SourceCode> {
@@ -41,7 +42,10 @@ impl Diagnostic for TestDiagnostic {
 }
 
 fn diagnostic() -> TestDiagnostic {
-    TestDiagnostic { source: NamedSource::new("test.js", String::from("let ? = 1;")) }
+    TestDiagnostic {
+        source: NamedSource::new("test.js", String::from("let ? = 1;")),
+        labels: [LabeledSpan::at(4..5, "here")],
+    }
 }
 
 #[test]

--- a/tests/single_scan.rs
+++ b/tests/single_scan.rs
@@ -12,8 +12,8 @@
 use std::fmt;
 
 use miette::{
-    Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, Labels, NamedSource,
-    SourceCode, SourceSpan, SpanContents,
+    Diagnostic, GraphicalReportHandler, GraphicalTheme, LabeledSpan, NamedSource, SourceCode,
+    SourceSpan, SpanContents,
 };
 
 /// Deterministic xorshift so any failure reproduces from a fixed seed.
@@ -71,8 +71,8 @@ impl<S: SourceCode + fmt::Debug> Diagnostic for TestDiag<S> {
         Some(&self.src)
     }
 
-    fn labels(&self) -> Labels {
-        Labels::Many(self.labels.clone())
+    fn labels(&self) -> &[LabeledSpan] {
+        &self.labels
     }
 }
 


### PR DESCRIPTION
Borrow diagnostic labels and keep source metadata on SourceCode, removing renderer-owned storage and compatibility wrappers.

AI-assisted by OpenAI Codex.