### PR TITLE
fix(protocol): preserve public trait implementations

### DIFF
--- a/src/named_source.rs
+++ b/src/named_source.rs
@@ -5,7 +5,7 @@ use crate::SourceCode;
 /// Utility struct for when you have a regular [`SourceCode`] type that doesn't
 /// implement `name`. For example [`String`]. Or if you want to override the
 /// `name` returned by the `SourceCode`.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NamedSource<S: SourceCode + 'static> {
     source: S,
     name: String,

--- a/src/source_impls.rs
+++ b/src/source_impls.rs
@@ -765,6 +765,12 @@ impl<'a> SpanScanner<'a> {
     }
 }
 
+impl SourceCode for [u8] {
+    fn data(&self) -> &[u8] {
+        self
+    }
+}
+
 impl SourceCode for str {
     fn data(&self) -> &[u8] {
         self.as_bytes()

--- a/tests/protocol.rs
+++ b/tests/protocol.rs
@@ -1,6 +1,6 @@
-use std::fmt;
+use std::{fmt, hash::Hash};
 
-use miette::{Diagnostic, SourceSpan};
+use miette::{Diagnostic, NamedSource, SourceCode, SourceSpan};
 
 #[derive(Debug)]
 struct TestDiagnostic;
@@ -25,4 +25,13 @@ fn spans_convert_from_offsets_and_ranges() {
 fn diagnostics_can_be_owned_as_trait_objects() {
     let diagnostic: Box<dyn Diagnostic + Send + Sync> = Box::new(TestDiagnostic);
     assert_eq!(diagnostic.to_string(), "broken");
+}
+
+#[test]
+fn public_trait_implementations_are_preserved() {
+    fn assert_named_source_traits<T: Clone + Eq + Ord + Hash>() {}
+    fn assert_source_code<T: SourceCode + ?Sized>() {}
+
+    assert_named_source_traits::<NamedSource<String>>();
+    assert_source_code::<[u8]>();
 }


### PR DESCRIPTION
Restore the public `NamedSource` trait implementations and `[u8]: SourceCode` compatibility removed by #307. Retain the internal `SpanContents` cleanup and add compile-time guards for the public surface.